### PR TITLE
measure and speed up rstudio desktop startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## RStudio 2026.10.0 "Blue Mistflower" Release Notes
 
 ### New
--
+- RStudio Desktop starts faster: the IDE is served while R initializes, R is queried once instead of twice when it is detected, and on macOS the login shell is consulted for the PATH by the desktop in the background instead of by the session on every launch. Set `RSTUDIO_STARTUP_TIMING=<file>` to record startup checkpoints from the desktop, the session, and the client.
 
 ### Fixed
 -

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## RStudio 2026.10.0 "Blue Mistflower" Release Notes
 
 ### New
-- RStudio Desktop starts faster: the IDE is served while R initializes, R is queried once instead of twice when it is detected, and on macOS the login shell is consulted for the PATH by the desktop in the background instead of by the session on every launch. Set `RSTUDIO_STARTUP_TIMING=<file>` to record startup checkpoints from the desktop, the session, and the client.
+- Optimized RStudio Desktop startup time.
 
 ### Fixed
 -

--- a/e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts
+++ b/e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts
@@ -48,14 +48,19 @@ const RESTORE_VIMRC = [
 ].join(' ');
 
 // True once a mapping with the given keys has been registered with the Vim
-// emulation (user mappings land in the shared keymap).
+// emulation (user mappings land in the shared keymap). The vim module loads
+// lazily -- requested by the first editor that applies vim keybindings -- so
+// "module not loaded yet" reads as "mapping not registered yet".
 function vimMappingRegistered(page: Page, keys: string): Promise<boolean> {
   return page.evaluate((mappedKeys) => {
     const w = window as unknown as {
-      require(id: string): { handler: { defaultKeymap: Array<{ keys?: string }> } };
+      require(id: string): { handler: { defaultKeymap: Array<{ keys?: string }> } } | undefined;
     };
-    const handler = w.require('ace/keyboard/vim').handler;
-    return handler.defaultKeymap.some((mapping) => mapping.keys === mappedKeys);
+    const vim = w.require('ace/keyboard/vim');
+    if (!vim) {
+      return false;
+    }
+    return vim.handler.defaultKeymap.some((mapping) => mapping.keys === mappedKeys);
   }, keys);
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "rserver-dev": "node tasks/rserver-dev.ts",
     "rserver-stop": "node tasks/rserver-stop.ts",
-    "rserver-status": "node tasks/rserver-status.ts"
+    "rserver-status": "node tasks/rserver-status.ts",
+    "startup-timing": "node tasks/startup-timing.ts"
   },
   "engines": {
     "node": ">=22.18.0"

--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -47,6 +47,7 @@ set(CORE_SOURCE_FILES
    RecursionGuard.cpp
    Settings.cpp
    SocketRpc.cpp
+   StartupTiming.cpp
    StringUtils.cpp
    SqlIdentifier.cpp
    ColorUtils.cpp

--- a/src/cpp/core/StartupTiming.cpp
+++ b/src/cpp/core/StartupTiming.cpp
@@ -16,6 +16,7 @@
 #include <core/StartupTiming.hpp>
 
 #include <chrono>
+#include <cstdio>
 #include <fstream>
 #include <iomanip>
 
@@ -42,6 +43,40 @@ double nowMs()
    return duration<double, std::milli>(system_clock::now().time_since_epoch()).count();
 }
 
+// escape a checkpoint name for embedding in a JSON string: names can carry
+// request URIs, and an unescaped quote or backslash would tear the line
+std::string escaped(const std::string& name)
+{
+   std::string result;
+   result.reserve(name.size());
+
+   for (char ch : name)
+   {
+      switch (ch)
+      {
+      case '\\':
+         result += "\\\\";
+         break;
+      case '"':
+         result += "\\\"";
+         break;
+      default:
+         if (static_cast<unsigned char>(ch) < 0x20)
+         {
+            char buffer[8];
+            snprintf(buffer, sizeof(buffer), "\\u%04x", static_cast<unsigned char>(ch));
+            result += buffer;
+         }
+         else
+         {
+            result += ch;
+         }
+      }
+   }
+
+   return result;
+}
+
 void write(const std::string& name, double t, double durationMs)
 {
    // the desktop and session processes append to the same file; small
@@ -51,7 +86,7 @@ void write(const std::string& name, double t, double durationMs)
       return;
 
    out << std::fixed << std::setprecision(3)
-       << "{\"tier\":\"session\",\"name\":\"" << name << "\""
+       << "{\"tier\":\"session\",\"name\":\"" << escaped(name) << "\""
        << ",\"t\":" << t
        << ",\"pid\":" << core::system::currentProcessId();
 

--- a/src/cpp/core/StartupTiming.cpp
+++ b/src/cpp/core/StartupTiming.cpp
@@ -1,0 +1,103 @@
+/*
+ * StartupTiming.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/StartupTiming.hpp>
+
+#include <chrono>
+#include <fstream>
+#include <iomanip>
+
+#include <core/system/Environment.hpp>
+#include <core/system/System.hpp>
+
+namespace rstudio {
+namespace core {
+namespace startup_timing {
+
+namespace {
+
+// resolved once; the environment variable is inherited from the desktop
+// front-end (or set by hand), so it cannot change during the process lifetime
+const std::string& timingFile()
+{
+   static const std::string s_path = core::system::getenv("RSTUDIO_STARTUP_TIMING");
+   return s_path;
+}
+
+double nowMs()
+{
+   using namespace std::chrono;
+   return duration<double, std::milli>(system_clock::now().time_since_epoch()).count();
+}
+
+void write(const std::string& name, double t, double durationMs)
+{
+   // the desktop and session processes append to the same file; small
+   // O_APPEND writes are atomic enough for one line per checkpoint
+   std::ofstream out(timingFile(), std::ios::app);
+   if (!out)
+      return;
+
+   out << std::fixed << std::setprecision(3)
+       << "{\"tier\":\"session\",\"name\":\"" << name << "\""
+       << ",\"t\":" << t
+       << ",\"pid\":" << core::system::currentProcessId();
+
+   if (durationMs >= 0)
+      out << ",\"dur\":" << durationMs;
+
+   out << "}\n";
+}
+
+} // anonymous namespace
+
+bool enabled()
+{
+   return !timingFile().empty();
+}
+
+void checkpoint(const std::string& name)
+{
+   if (!enabled())
+      return;
+
+   write(name, nowMs(), -1);
+}
+
+void checkpoint(const std::string& name, double durationMs)
+{
+   if (!enabled())
+      return;
+
+   write(name, nowMs(), durationMs);
+}
+
+ScopedCheckpoint::ScopedCheckpoint(const std::string& name)
+   : name_(name),
+     start_(enabled() ? nowMs() : 0)
+{
+}
+
+ScopedCheckpoint::~ScopedCheckpoint()
+{
+   if (!enabled())
+      return;
+
+   write(name_, nowMs(), nowMs() - start_);
+}
+
+} // namespace startup_timing
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/gwt/GwtFileHandler.cpp
+++ b/src/cpp/core/gwt/GwtFileHandler.cpp
@@ -46,6 +46,7 @@ struct FileRequestOptions
    bool useEmulatedStack;
    std::string serverHomepagePath;
    std::string frameOptions;
+   bool compress;
 };
 
 void handleFileRequest(const FileRequestOptions& options,
@@ -113,14 +114,14 @@ void handleFileRequest(const FileRequestOptions& options,
    if (regex_utils::match(uri, boost::regex(".*\\.cache\\..*")))
    {
       pResponse->setCacheForeverHeaders();
-      pResponse->setFile(filePath, request);
+      pResponse->setFile(filePath, request, options.compress);
    }
-   
-   // case: files designated to never be cached 
+
+   // case: files designated to never be cached
    else if (regex_utils::match(uri, boost::regex(".*\\.nocache\\..*")))
    {
       pResponse->setNoCacheHeaders();
-      pResponse->setFile(filePath, request);
+      pResponse->setFile(filePath, request, options.compress);
    }
    // case: main page -- don't cache and dynamically set compiler stack mode
    else if (uri == mainPage)
@@ -161,7 +162,7 @@ void handleFileRequest(const FileRequestOptions& options,
 
       // return the page
       pResponse->setNoCacheHeaders();
-      pResponse->setFile(filePath, request, text::TemplateFilter(vars));
+      pResponse->setFile(filePath, request, text::TemplateFilter(vars), options.compress);
    }
    // case: normal cacheable file
    else
@@ -182,11 +183,12 @@ http::UriHandlerFunction fileHandlerFunction(
                                        const std::string& gwtPrefix,
                                        bool useEmulatedStack,
                                        const std::string& serverHomepagePath,
-                                       const std::string& frameOptions)
+                                       const std::string& frameOptions,
+                                       bool compress)
 {
    FileRequestOptions options { wwwLocalPath, baseUri, mainPageFilter, initJs,
                                 gwtPrefix, useEmulatedStack, serverHomepagePath,
-                                frameOptions };
+                                frameOptions, compress };
 
    return boost::bind(handleFileRequest,
                       options,

--- a/src/cpp/core/gwt/GwtFileHandler.cpp
+++ b/src/cpp/core/gwt/GwtFileHandler.cpp
@@ -169,7 +169,7 @@ void handleFileRequest(const FileRequestOptions& options,
    {
       // since these are application components we force revalidation (default behavior of
       // setCacheableFile)
-      pResponse->setCacheableFile(filePath, request);
+      pResponse->setCacheableFile(filePath, request, options.compress);
    }
 }
    

--- a/src/cpp/core/gwt/GwtFileHandler.cpp
+++ b/src/cpp/core/gwt/GwtFileHandler.cpp
@@ -114,7 +114,23 @@ void handleFileRequest(const FileRequestOptions& options,
    if (regex_utils::match(uri, boost::regex(".*\\.cache\\..*")))
    {
       pResponse->setCacheForeverHeaders();
-      pResponse->setFile(filePath, request, options.compress);
+
+      // prefer a precompressed sibling (produced at build time for the large
+      // content-hashed assets): its compression cost has already been paid,
+      // so it is worthwhile even where runtime compression is not (see
+      // options.compress)
+      FilePath gzPath(filePath.getAbsolutePath() + ".gz");
+      if (gzPath.exists() && request.acceptsEncoding(http::kGzipEncoding))
+      {
+         pResponse->setContentType(filePath.getMimeContentType());
+         pResponse->setContentEncoding(http::kGzipEncoding);
+         pResponse->addHeader("Vary", "Accept-Encoding");
+         pResponse->setFile(gzPath, request, false);
+      }
+      else
+      {
+         pResponse->setFile(filePath, request, options.compress);
+      }
    }
 
    // case: files designated to never be cached

--- a/src/cpp/core/include/core/StartupTiming.hpp
+++ b/src/cpp/core/include/core/StartupTiming.hpp
@@ -1,0 +1,55 @@
+/*
+ * StartupTiming.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_STARTUP_TIMING_HPP
+#define CORE_STARTUP_TIMING_HPP
+
+#include <string>
+
+namespace rstudio {
+namespace core {
+namespace startup_timing {
+
+// Startup checkpoints are recorded only when RSTUDIO_STARTUP_TIMING names a
+// file. Each checkpoint appends one JSON line of the form
+//
+//    {"tier":"session","name":"<name>","t":<epoch ms>,"pid":<pid>}
+//
+// with an optional "dur" (milliseconds) for checkpoints that describe a
+// completed span. The desktop front-end and the GWT client write to the same
+// file, so a single timeline can be reconstructed across all three processes
+// by sorting on "t". See tasks/startup-timing.ts for the report.
+bool enabled();
+
+void checkpoint(const std::string& name);
+void checkpoint(const std::string& name, double durationMs);
+
+// Records "<name>" with the elapsed time of the enclosing scope as "dur".
+class ScopedCheckpoint
+{
+public:
+   explicit ScopedCheckpoint(const std::string& name);
+   ~ScopedCheckpoint();
+
+private:
+   std::string name_;
+   double start_;
+};
+
+} // namespace startup_timing
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_STARTUP_TIMING_HPP

--- a/src/cpp/core/include/core/gwt/GwtFileHandler.hpp
+++ b/src/cpp/core/include/core/gwt/GwtFileHandler.hpp
@@ -30,7 +30,8 @@ http::UriHandlerFunction fileHandlerFunction(
       const std::string& gwtPrefix = std::string(),
       bool useEmulatedStack = false,
       const std::string& serverHomepagePath = std::string(),
-      const std::string& frameOptions = std::string());
+      const std::string& frameOptions = std::string(),
+      bool compress = true);
    
 } // namespace gwt
 } // namespace core

--- a/src/cpp/core/include/core/http/Response.hpp
+++ b/src/cpp/core/include/core/http/Response.hpp
@@ -308,16 +308,20 @@ public:
 
    void setDynamicHtml(const std::string& html, const Request& request);
    
-   void setFile(const FilePath& filePath, const Request& request)
+   void setFile(const FilePath& filePath, const Request& request, bool compress = true)
    {
       NullOutputFilter nullFilter;
-      setFile(filePath, request, nullFilter);
+      setFile(filePath, request, nullFilter, compress);
    }
-   
+
+   // compress: gzip the body when the client accepts it. Worth it over a
+   // network, but on a loopback connection compressing a large file costs
+   // far more than sending it uncompressed.
    template <typename Filter>
-   void setFile(const FilePath& filePath, 
-                const Request& request, 
-                const Filter& filter)
+   void setFile(const FilePath& filePath,
+                const Request& request,
+                const Filter& filter,
+                bool compress = true)
    {
       // ensure that the file exists
       if (!filePath.exists())
@@ -325,18 +329,18 @@ public:
          setNotFoundError(request);
          return;
       }
-      
+
       // set content type
       if (contentType().empty())
       {
          setContentType(filePath.getMimeContentType());
       }
-      
+
       // gzip if possible
-      if (contentEncoding().empty() && request.acceptsEncoding(kGzipEncoding))
+      if (compress && contentEncoding().empty() && request.acceptsEncoding(kGzipEncoding))
          setContentEncoding(kGzipEncoding);
 
-      Error error = setBody(filePath, filter, 128, usePadding(request, filePath));
+      Error error = setBody(filePath, filter, 65536, usePadding(request, filePath));
       if (error)
          setError(status::InternalServerError, error.getMessage());
    }

--- a/src/cpp/core/include/core/http/Response.hpp
+++ b/src/cpp/core/include/core/http/Response.hpp
@@ -360,10 +360,10 @@ public:
     * @param filePath  The file to set as the response.
     * @param request   The HTTP request from the browser.
     */
-   void setCacheableFile(const FilePath& filePath, const Request& request)
+   void setCacheableFile(const FilePath& filePath, const Request& request, bool compress = true)
    {
       setCacheWithRevalidationHeaders();
-      setIndefiniteCacheableFile(filePath, request);
+      setIndefiniteCacheableFile(filePath, request, compress);
    }
 
    /**
@@ -377,12 +377,13 @@ public:
     * @param filter    An output filter through which to process the file contents.
     */
    template <typename Filter>
-   void setCacheableFile(const FilePath& filePath, 
-                         const Request& request, 
-                         const Filter& filter)
+   void setCacheableFile(const FilePath& filePath,
+                         const Request& request,
+                         const Filter& filter,
+                         bool compress = true)
    {
       setCacheWithRevalidationHeaders();
-      setIndefiniteCacheableFile(filePath, request, filter);
+      setIndefiniteCacheableFile(filePath, request, filter, compress);
    }
 
    /**
@@ -392,10 +393,10 @@ public:
     * @param filePath  The file to set as the response.
     * @param request   The HTTP request from the browser.
     */
-   void setIndefiniteCacheableFile(const FilePath& filePath, const Request& request)
+   void setIndefiniteCacheableFile(const FilePath& filePath, const Request& request, bool compress = true)
    {
       NullOutputFilter nullFilter;
-      setIndefiniteCacheableFile(filePath, request, nullFilter);
+      setIndefiniteCacheableFile(filePath, request, nullFilter, compress);
    }
    
    /**
@@ -408,9 +409,10 @@ public:
     * @param filter    An output filter through which to process the file contents.
     */
    template <typename Filter>
-   void setIndefiniteCacheableFile(const FilePath& filePath, 
-                                   const Request& request, 
-                                   const Filter& filter)
+   void setIndefiniteCacheableFile(const FilePath& filePath,
+                                   const Request& request,
+                                   const Filter& filter,
+                                   bool compress = true)
    {
       // ensure that the file exists
       if (!filePath.exists())
@@ -432,7 +434,7 @@ public:
       }
       else
       {
-         setFile(filePath, request, filter);
+         setFile(filePath, request, filter, compress);
       }
    }
    void setRangeableFile(const FilePath& filePath, const Request& request);

--- a/src/cpp/r/session/REmbeddedPosix.cpp
+++ b/src/cpp/r/session/REmbeddedPosix.cpp
@@ -16,6 +16,7 @@
 #include <cstring>
 
 #include <core/Log.hpp>
+#include <core/StartupTiming.hpp>
 
 #include <r/RRuntime.hpp>
 #include <r/session/REventLoop.hpp>
@@ -124,7 +125,9 @@ void runEmbeddedR(const core::FilePath& /*rHome*/,    // ignored on posix
 
    // initialize R
    const char *args[]= {"RStudio", "--interactive"};
+   core::startup_timing::checkpoint("r-initialize-begin");
    Rf_initialize_R(sizeof(args)/sizeof(args[0]), (char**)args);
+   core::startup_timing::checkpoint("r-initialized");
 
    // For newSession = false we need to do a few things:
    //
@@ -223,8 +226,10 @@ void runEmbeddedR(const core::FilePath& /*rHome*/,    // ignored on posix
       R_Suicide("RStudio failed to initialize R runtime dispatch");
    }
 
-   // initialize the main loop
+   // initialize the main loop (this is where Rprofile.site and .Rprofile run)
+   core::startup_timing::checkpoint("r-mainloop-setup-begin");
    setup_Rmainloop();
+   core::startup_timing::checkpoint("r-mainloop-setup-end");
 
    // run the main loop
    run_Rmainloop();

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -31,6 +31,7 @@
 
 #include <core/Exec.hpp>
 #include <core/Log.hpp>
+#include <core/StartupTiming.hpp>
 #include <core/StringUtils.hpp>
 #include <core/Version.hpp>
 #include <core/system/Environment.hpp>
@@ -395,7 +396,9 @@ void runEmbeddedR(const core::FilePath& rHome,
    ::_wsetlocale(LC_NUMERIC, L"C");
 
    // setup main loop
+   core::startup_timing::checkpoint("r-mainloop-setup-begin");
    ::setup_Rmainloop();
+   core::startup_timing::checkpoint("r-mainloop-setup-end");
 
    // reset character mode to RGui
    CharacterMode = RGui;

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/bind/bind.hpp>
 
+#include <core/StartupTiming.hpp>
 #include <core/system/Environment.hpp>
 
 #include <r/RExec.hpp>
@@ -214,6 +215,8 @@ void restoreSession(const FilePath& suspendedSessionPath,
 // one-time per session initialization
 Error initialize()
 {
+   core::startup_timing::checkpoint("r-session-init-begin");
+
    // ensure that the utils package is loaded (it might not be loaded
    // if R is attempting to recover from a library loading error which
    // occurs during .Rprofile)
@@ -259,7 +262,7 @@ Error initialize()
    error = r::sourceManager().sourceTools(globalCallingHandlersFilePath);
    if (error)
       return error;
-
+   core::startup_timing::checkpoint("r-tools-sourced");
 
    // initialize graphics device -- use a stable directory for server mode
    // and temp directory for desktop mode (so that we can support multiple
@@ -329,7 +332,8 @@ Error initialize()
       // defer loading of global environment
       s_deferredDeserializationAction = deferredRestoreNewSession;
    }
-   
+   core::startup_timing::checkpoint("r-state-restored");
+
    // initialize client
    RInitInfo rInitInfo(wasResumed);
    error = rCallbacks().init(rInitInfo);
@@ -384,6 +388,8 @@ Error initialize()
    }
 #endif
 
+   core::startup_timing::checkpoint("r-session-init-end");
+
    // now run hooks for those waiting for session to be fully initialized
    if (rCallbacks().initComplete)
       rCallbacks().initComplete();
@@ -400,7 +406,8 @@ void ensureDeserialized()
 {
    if (s_deferredDeserializationAction)
    {
-      // do the deferred action
+      // do the deferred action (restores .RData or the suspended session)
+      core::startup_timing::ScopedCheckpoint timing("r-deserialize");
       s_deferredDeserializationAction();
       s_deferredDeserializationAction.clear();
    }

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -63,6 +63,7 @@
 #include <core/http/Cookie.hpp>
 #include <core/http/CSRFToken.hpp>
 #include <core/r_util/RSessionContext.hpp>
+#include <core/StartupTiming.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/Locale.hpp>
 
@@ -177,6 +178,8 @@ Error makePortTokenCookie(boost::shared_ptr<HttpConnection> ptrConnection,
 void handleClientInit(const boost::function<void()>& initFunction,
                       boost::shared_ptr<HttpConnection> ptrConnection)
 {
+   core::startup_timing::checkpoint("client-init-begin");
+
    // notify that we're about to initialize
    module_context::events().onBeforeClientInit();
    
@@ -736,16 +739,19 @@ void handleClientInit(const boost::function<void()>& initFunction,
 #endif
 
    ptrConnection->sendResponse(response);
+   core::startup_timing::checkpoint("client-init-response-sent");
 
    // complete initialization of session
    init::ensureSessionInitialized();
-   
+   core::startup_timing::checkpoint("session-initialized");
+
    // notify modules of the client init
    module_context::events().onClientInit();
-   
+
    // call the init function
    initFunction();
 
+   core::startup_timing::checkpoint("client-init-end");
    LOG_DEBUG_MESSAGE("End /rpc/client_init for client: " + clientId);
 }
 

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -33,6 +33,7 @@
 #include <shared_core/json/Json.hpp>
 #include <shared_core/Logger.hpp>
 
+#include <core/StartupTiming.hpp>
 #include <core/Thread.hpp>
 #include <core/gwt/GwtFileHandler.hpp>
 #include <core/gwt/GwtLogHandler.hpp>
@@ -497,6 +498,16 @@ bool waitForMethod(const std::string& method,
    // make sure to record it
    suspend::addBlockingOp(method, allowSuspend);
 
+   // the main thread only begins serving queued requests here; until now any
+   // request from the client (including the initial page load) has been
+   // waiting in the connection queue
+   static bool s_firstWait = true;
+   if (s_firstWait)
+   {
+      s_firstWait = false;
+      core::startup_timing::checkpoint("first-wait-for-method");
+   }
+
    // wait until we get the method we are looking for
    while (true)
    {
@@ -507,6 +518,13 @@ bool waitForMethod(const std::string& method,
       boost::shared_ptr<HttpConnection> ptrConnection =
           httpConnectionListener().mainConnectionQueue().dequeConnection(
                                             connectionQueueTimeout);
+
+      static bool s_firstConnection = true;
+      if (ptrConnection && s_firstConnection)
+      {
+         s_firstConnection = false;
+         core::startup_timing::checkpoint("first-request:" + ptrConnection->request().uri());
+      }
 
 
       // perform background processing (true for isIdle)

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -28,6 +28,8 @@
 
 #include "session-config.h"
 
+#include <atomic>
+
 #include <boost/algorithm/string.hpp>
 
 #include <shared_core/json/Json.hpp>
@@ -73,6 +75,11 @@ namespace session {
 namespace {
 
 core::http::UriHandlerFunction s_defaultUriHandler;
+
+// whether s_defaultUriHandler has been assigned; the listener thread gates
+// its static-asset fast path on this (an atomic, because in server mode the
+// assignment happens on the main thread while the listener is running)
+std::atomic<bool> s_gwtHandlersRegistered(false);
 
 // version of the executable -- this is the legacy version designator. we
 // set it to double max so that it always invalidates legacy clients
@@ -649,7 +656,7 @@ bool isStaticAssetRequest(boost::shared_ptr<HttpConnection> ptrConnection)
    // only GET requests that fall through to the GWT file handler: anything
    // with a module-registered handler, and every RPC or event request, needs
    // the main thread (and possibly R)
-   if (!s_defaultUriHandler)
+   if (!s_gwtHandlersRegistered.load(std::memory_order_acquire))
       return false;
 
    const core::http::Request& request = ptrConnection->request();
@@ -664,6 +671,17 @@ bool isStaticAssetRequest(boost::shared_ptr<HttpConnection> ptrConnection)
    }
 
    return !uri_handlers::handlers().handlerFor(uri);
+}
+
+void handleStaticAssetRequest(boost::shared_ptr<HttpConnection> ptrConnection)
+{
+   // serve with the default (GWT file) handler directly. the caller decided
+   // via isStaticAssetRequest() that no module handler applies; consulting
+   // the handler map again (as handleConnection() would) could pick up a
+   // handler registered in between and run it on the listener thread
+   core::http::Response response;
+   s_defaultUriHandler(ptrConnection->request(), &response);
+   ptrConnection->sendResponse(response);
 }
 
 bool isAsyncJsonRpcRequest(boost::shared_ptr<HttpConnection> ptrConnection)
@@ -1015,6 +1033,9 @@ void registerGwtHandlers()
                                                   std::string(),
                                                   std::string(),
                                                   compress);
+
+   // publish the handler to the listener thread (see isStaticAssetRequest)
+   s_gwtHandlersRegistered.store(true, std::memory_order_release);
 }
 
 namespace {

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -77,8 +77,9 @@ namespace {
 core::http::UriHandlerFunction s_defaultUriHandler;
 
 // whether s_defaultUriHandler has been assigned; the listener thread gates
-// its static-asset fast path on this (an atomic, because in server mode the
-// assignment happens on the main thread while the listener is running)
+// its static-asset fast path on this. registerGwtHandlers() runs (in desktop
+// and standalone modes only) before the listener thread starts, so the store
+// is always visible to it; the atomic is defensive, not load-bearing
 std::atomic<bool> s_gwtHandlersRegistered(false);
 
 // version of the executable -- this is the legacy version designator. we

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -644,6 +644,28 @@ bool isJsonRpcRequest(boost::shared_ptr<HttpConnection> ptrConnection)
                                          "/rpc/");
 }
 
+bool isStaticAssetRequest(boost::shared_ptr<HttpConnection> ptrConnection)
+{
+   // only GET requests that fall through to the GWT file handler: anything
+   // with a module-registered handler, and every RPC or event request, needs
+   // the main thread (and possibly R)
+   if (!s_defaultUriHandler)
+      return false;
+
+   const core::http::Request& request = ptrConnection->request();
+   if (request.method() != "GET")
+      return false;
+
+   const std::string& uri = request.uri();
+   if (boost::algorithm::starts_with(uri, "/rpc/") ||
+       boost::algorithm::starts_with(uri, "/events/"))
+   {
+      return false;
+   }
+
+   return !uri_handlers::handlers().handlerFor(uri);
+}
+
 bool isAsyncJsonRpcRequest(boost::shared_ptr<HttpConnection> ptrConnection)
 {
    std::string uri = ptrConnection->request().uri();
@@ -953,6 +975,13 @@ WaitResult startHttpConnectionListenerWithTimeout()
 
 void registerGwtHandlers()
 {
+   // called once, before the HTTP listener starts, so the listener thread can
+   // serve the client while R initializes (see isStaticAssetRequest)
+   static bool s_registered = false;
+   if (s_registered)
+      return;
+   s_registered = true;
+
    // alias options
    session::Options& options = session::options();
 
@@ -974,11 +1003,18 @@ void registerGwtHandlers()
    // declare program mode in JS init block (for GWT boot time access)
    std::string initJs = "window.program_mode = \"" + options.programMode() + "\";\n";
 
-   // set default handler
+   // set default handler; the desktop talks to us over loopback, where
+   // compressing the multi-megabyte client costs far more than sending it
+   bool compress = options.programMode() != kSessionProgramModeDesktop;
    s_defaultUriHandler = gwt::fileHandlerFunction(options.wwwLocalPath(),
                                                   "/",
                                                   http::UriFilterFunction(),
-                                                  initJs);
+                                                  initJs,
+                                                  std::string(),
+                                                  false,
+                                                  std::string(),
+                                                  std::string(),
+                                                  compress);
 }
 
 namespace {

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -679,7 +679,7 @@ void handleStaticAssetRequest(boost::shared_ptr<HttpConnection> ptrConnection)
    // serve with the default (GWT file) handler directly. the caller decided
    // via isStaticAssetRequest() that no module handler applies; consulting
    // the handler map again (as handleConnection() would) could pick up a
-   // handler registered in between and run it on the listener thread
+   // handler registered in between and run it off the main thread
    core::http::Response response;
    s_defaultUriHandler(ptrConnection->request(), &response);
    ptrConnection->sendResponse(response);

--- a/src/cpp/session/SessionHttpMethods.hpp
+++ b/src/cpp/session/SessionHttpMethods.hpp
@@ -48,6 +48,7 @@ void waitForMethodInitFunction(const ClientEvent& initEvent);
 bool isJsonRpcRequest(boost::shared_ptr<HttpConnection> ptrConnection);
 
 bool isAsyncJsonRpcRequest(boost::shared_ptr<HttpConnection> ptrConnection);
+bool isStaticAssetRequest(boost::shared_ptr<HttpConnection> ptrConnection);
 
 void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
                       ConnectionType connectionType);

--- a/src/cpp/session/SessionHttpMethods.hpp
+++ b/src/cpp/session/SessionHttpMethods.hpp
@@ -49,6 +49,7 @@ bool isJsonRpcRequest(boost::shared_ptr<HttpConnection> ptrConnection);
 
 bool isAsyncJsonRpcRequest(boost::shared_ptr<HttpConnection> ptrConnection);
 bool isStaticAssetRequest(boost::shared_ptr<HttpConnection> ptrConnection);
+void handleStaticAssetRequest(boost::shared_ptr<HttpConnection> ptrConnection);
 
 void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
                       ConnectionType connectionType);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -840,12 +840,8 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       registerRpcMethod(json::adaptMethodToAsync(method));
    }
 
-   // add gwt handlers if we are running desktop mode
-   if ((rsession::options().programMode() == kSessionProgramModeDesktop) ||
-       rsession::options().standalone())
-   {
-      http_methods::registerGwtHandlers();
-   }
+   // (the gwt handlers used in desktop and standalone modes are registered in
+   // rsessionMain, before the http listener starts)
 
    // enque abend warning event if necessary (but not in standalone
    // mode since those processes are often aborted unceremoniously)
@@ -2756,6 +2752,14 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
 
       // initialize directory trust state before R initialization
       modules::trust::initializeTrustState();
+
+      // in desktop and standalone modes we serve the client ourselves; register
+      // the handlers before listening so the listener thread can serve the
+      // page and its assets while R initializes below
+      if ((options.programMode() == kSessionProgramModeDesktop) || options.standalone())
+      {
+         http_methods::registerGwtHandlers();
+      }
 
       // start http connection listener
       error = waitWithTimeout(

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -48,6 +48,7 @@
 #include <core/ConfigUtils.hpp>
 #include <core/FileLock.hpp>
 #include <core/Exec.hpp>
+#include <core/StartupTiming.hpp>
 #include <core/Scope.hpp>
 #include <core/Settings.hpp>
 #include <core/Thread.hpp>
@@ -570,6 +571,8 @@ void setPartnerEnvironmentVariables()
 
 Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
 {
+   core::startup_timing::checkpoint("session-init-begin");
+
    // save state we need to reference later
    suspend::setSessionResumed(rInitInfo.resumed);
 
@@ -797,6 +800,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    Error error = initialize.execute();
    if (error)
       return error;
+   core::startup_timing::checkpoint("modules-initialized");
 
    // if we are in verify installation mode then we should exit (successfully) now
    if (rsession::options().verifyInstallation())
@@ -919,6 +923,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    main_process::setupForkHandlers();
 
    // success!
+   core::startup_timing::checkpoint("session-init-end");
    return Success();
 }
 
@@ -926,6 +931,7 @@ void rInitComplete()
 {
    module_context::syncRSaveAction();
    module_context::events().onInitComplete();
+   core::startup_timing::checkpoint("init-complete");
 }
 
 // Set during startup when the initial working directory is too long for Windows to
@@ -1007,10 +1013,12 @@ void rSessionInitHook(bool newSession)
    // fire an event to the client
    ClientEvent event(client_events::kDeferredInitCompleted, dataJson);
    module_context::enqueClientEvent(event);
+   core::startup_timing::checkpoint("deferred-init-completed");
 }
 
 void rDeferredInit(bool newSession)
 {
+   core::startup_timing::ScopedCheckpoint timing("deferred-init");
    module_context::events().onDeferredInit(newSession);
 
    // schedule execution of the session init hook
@@ -2217,6 +2225,8 @@ void mainThreadWorkaround()
 // and the comments in SessionMain.hpp and CMakeLists.txt.
 RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
 {
+   core::startup_timing::checkpoint("main");
+
    mainThreadWorkaround();
 
    try
@@ -2269,6 +2279,7 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
          if (error)
             LOG_ERROR(error);
       }
+      core::startup_timing::checkpoint("path-initialized");
 
       // terminate immediately with given exit code (for testing/debugging)
       std::string exitOnStartup = core::system::getenv("RSTUDIO_SESSION_EXIT_ON_STARTUP");
@@ -2307,6 +2318,7 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
                                   core::log::LogLevel::WARN,
                                   core::system::xdg::userLogDir(),
                                   true); // force log dir to be under user's home directory
+      core::startup_timing::checkpoint("log-initialized");
 
       // report any failure from initHook(), which ran before logging was up
 #ifdef _WIN32
@@ -2379,12 +2391,14 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
       error = socket_rpc::initialize();
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
+      core::startup_timing::checkpoint("options-read-begin");
 
       // read program options
       std::ostringstream osWarnings;
       Options& options = rsession::options();
       ProgramStatus status = options.read(argc, argv, osWarnings);
       std::string optionsWarnings = osWarnings.str();
+      core::startup_timing::checkpoint("options-read");
 
       if (!optionsWarnings.empty())
          program_options::reportWarnings(optionsWarnings, ERROR_LOCATION);
@@ -2687,10 +2701,12 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
       error = prefs::initializeState();
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
+      core::startup_timing::checkpoint("prefs-initialized");
 
       // startup projects -- must be after userSettings is initialized
       // but before persistentState and setting working directory
       projects::startup(firstProjectPath);
+      core::startup_timing::checkpoint("projects-started");
 
       // initialize persistent state
       error = rsession::persistentState().initialize();
@@ -2746,6 +2762,7 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
             http_methods::startHttpConnectionListenerWithTimeout, 0, 100, 1);
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
+      core::startup_timing::checkpoint("http-listener-started");
 
       // start session proxy to route traffic to localhost-listening applications (like Shiny)
       // this has to come after regular overlay initialization as it depends on persistent state
@@ -2954,6 +2971,7 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
       }
 
       // run r (does not return, terminates process using exit)
+      core::startup_timing::checkpoint("r-run");
       error = rstudio::r::session::run(rOptions, rCallbacks);
       if (error)
       {

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2754,8 +2754,8 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
       modules::trust::initializeTrustState();
 
       // in desktop and standalone modes we serve the client ourselves; register
-      // the handlers before listening so the listener thread can serve the
-      // page and its assets while R initializes below
+      // the handlers before listening so the page and its assets can be
+      // served while R initializes below
       if ((options.programMode() == kSessionProgramModeDesktop) || options.standalone())
       {
          http_methods::registerGwtHandlers();

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -53,6 +53,7 @@
 #include <core/system/Process.hpp>
 #include <core/system/FileMonitor.hpp>
 #include <core/system/FileChangeEvent.hpp>
+#include <core/StartupTiming.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/ShellUtils.hpp>
 #include <core/system/System.hpp>
@@ -2248,6 +2249,7 @@ std::string libPathsString()
 
 Error sourceModuleRFile(const std::string& rSourceFile)
 {
+   core::startup_timing::ScopedCheckpoint timing("source:" + rSourceFile);
    FilePath modulesPath = session::options().modulesRSourcePath();
    FilePath srcPath = modulesPath.completePath(rSourceFile);
    return r::sourceManager().sourceTools(srcPath);

--- a/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
@@ -367,7 +367,7 @@ private:
       // does not drain the connection queue until R has fully initialized
       if (http_methods::isStaticAssetRequest(ptrHttpConnection))
       {
-         http_methods::handleConnection(ptrHttpConnection, http_methods::ForegroundConnection);
+         http_methods::handleStaticAssetRequest(ptrHttpConnection);
          return;
       }
 

--- a/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
@@ -362,6 +362,15 @@ private:
       if (connection::checkForInterrupt(ptrHttpConnection))
          return;
 
+      // serve static client assets (the GWT page, scripts and styles) right
+      // here: they need neither R nor the main thread, and the main thread
+      // does not drain the connection queue until R has fully initialized
+      if (http_methods::isStaticAssetRequest(ptrHttpConnection))
+      {
+         http_methods::handleConnection(ptrHttpConnection, http_methods::ForegroundConnection);
+         return;
+      }
+
       // place the connection on the correct queue
       if (connection::isGetEvents(ptrHttpConnection))
       {

--- a/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
@@ -126,6 +126,19 @@ public:
                                            &(acceptorService_.ioContext())));
          listenerThread_ = MOVE_THREAD(listenerThread);
 
+         // in desktop and standalone modes the session serves the client's
+         // static assets itself (see registerGwtHandlers); launch the thread
+         // that serves them, so their file reads and socket writes never
+         // stall the listener thread
+         if (options().programMode() == kSessionProgramModeDesktop ||
+             options().standalone())
+         {
+            boost::thread staticAssetThread(
+                  bind(&HttpConnectionListenerImpl<ProtocolType>::serveStaticAssets,
+                       this));
+            staticAssetThread_ = MOVE_THREAD(staticAssetThread);
+         }
+
          // set started flag
          started_ = true;
 
@@ -160,6 +173,13 @@ public:
             listenerThread_,
             "HttpConnectionListener thread",
             false); // released via ioContext().stop() above, not interruptible
+
+      // wait for the static asset thread (a no-op if it was never started);
+      // the interrupt releases it from its queue wait
+      core::thread::joinOrAbandonThread(
+            staticAssetThread_,
+            "Static asset thread",
+            true);
 
       // allow subclass specific cleanup
       core::Error error = cleanup();
@@ -362,12 +382,14 @@ private:
       if (connection::checkForInterrupt(ptrHttpConnection))
          return;
 
-      // serve static client assets (the GWT page, scripts and styles) right
-      // here: they need neither R nor the main thread, and the main thread
-      // does not drain the connection queue until R has fully initialized
+      // hand static client assets (the GWT page, scripts and styles) to
+      // their own thread: they need neither R nor the main thread (which
+      // does not drain the connection queue until R has fully initialized),
+      // and their file reads and socket writes must not stall this thread,
+      // which accepts every connection and services abort/suspend/interrupt
       if (http_methods::isStaticAssetRequest(ptrHttpConnection))
       {
-         http_methods::handleStaticAssetRequest(ptrHttpConnection);
+         staticAssetQueue_.enqueConnection(ptrHttpConnection);
          return;
       }
 
@@ -428,6 +450,28 @@ private:
       }
    }
 
+   // serve static asset requests handed over by enqueConnection, one at a
+   // time, until stop() interrupts the queue wait
+   void serveStaticAssets()
+   {
+      try
+      {
+         while (true)
+         {
+            boost::shared_ptr<HttpConnection> ptrConnection =
+                  staticAssetQueue_.dequeConnection(
+                        boost::posix_time::milliseconds(500));
+            if (ptrConnection)
+               http_methods::handleStaticAssetRequest(ptrConnection);
+         }
+      }
+      catch(const boost::thread_interrupted&)
+      {
+         // stop() shutting the thread down
+      }
+      CATCH_UNEXPECTED_EXCEPTION
+   }
+
 private:
 
    // acceptor service (includes io service)
@@ -439,9 +483,13 @@ private:
    // connection queues
    HttpConnectionQueue mainConnectionQueue_;
    HttpConnectionQueue eventsConnectionQueue_;
+   HttpConnectionQueue staticAssetQueue_;
 
    // listener thread
    boost::thread listenerThread_;
+
+   // static asset thread (desktop and standalone modes only)
+   boost::thread staticAssetThread_;
 
    // flag indicating we've started
    std::atomic<bool> started_;

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -156,10 +156,17 @@ Error initializePathViaShell(const std::string& shellPath,
 // might.
 std::string initializePath()
 {
+   std::string defaultPath = core::system::getenv("PATH");
+
+   // RStudio Desktop asks the login shell itself, while Electron is still
+   // starting, and hands the result over with this marker set; asking again
+   // here would put the shell's startup cost back on the critical path
+   if (core::system::getenv("RSTUDIO_SESSION_PATH_INITIALIZED") == "1")
+      return defaultPath;
+
    // if the user's path already contains '/usr/local/bin', assume that
    // they're running RStudio through a shell / terminal and so we don't
    // need to re-read the shell PATH
-   std::string defaultPath = core::system::getenv("PATH");
    boost::regex reUsrLocalbin("(^|:)/usr/local/bin/?(:|$)");
    if (boost::regex_search(defaultPath, reUsrLocalbin))
       return defaultPath;

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -99,6 +99,13 @@ if(GWT_BUILD)
    # depend on Java source files
    file(GLOB_RECURSE GWT_SOURCE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.java")
 
+   # module definitions and the build logic itself must also invalidate the build
+   file(GLOB_RECURSE GWT_MODULE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.gwt.xml")
+   list(APPEND GWT_SOURCE_FILES
+      ${GWT_MODULE_FILES}
+      "${CMAKE_CURRENT_SOURCE_DIR}/build.xml"
+      "${CMAKE_CURRENT_SOURCE_DIR}/tools/precompress.js")
+
    # generated during GWT build command
    set(GWT_BUILD_TIMESTAMP "${CMAKE_CURRENT_BINARY_DIR}/timestamp")
 

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -277,6 +277,11 @@
    <set-if-exists property="yarn.bin" value="${node.dir}/node_modules/yarn/bin/yarn.cmd"/>
    <set-if-unset  property="yarn.bin" value="yarn"/>
 
+   <!-- use node from dependencies if available, otherwise from the system -->
+   <set-if-exists property="node.bin" value="${node.dir}/bin/node"/>
+   <set-if-exists property="node.bin" value="${node.dir}/node.exe"/>
+   <set-if-unset  property="node.bin" value="node"/>
+
    <!-- similar lookup for panmirror -->
    <set-if-exists property="panmirror.dir" value="/opt/rstudio-tools/src/gwt/lib/quarto/apps/panmirror"/>
    <set-if-exists property="panmirror.dir" value="c:/rstudio-tools/src/gwt/lib/quarto/apps/panmirror"/>
@@ -375,6 +380,14 @@
          <!-- Additional arguments like -logLevel DEBUG -->
          <arg value="${gwt.main.module}"/>
       </java>
+
+      <!-- precompress the large content-hashed outputs so the session can
+           serve them with Content-Encoding: gzip at zero runtime cost
+           (node is already required by the panmirror step above) -->
+      <exec executable="${node.bin}" resolveexecutable="true" failonerror="true">
+         <arg value="tools/precompress.js"/>
+         <arg value="${www.dir}/rstudio"/>
+      </exec>
    </target>
 
    <target name="soyc" description="Generate and show SOYC report">

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -614,10 +614,6 @@
    <set-if-exists property="npm.bin" value="${node.dir}/npm.cmd"/>
    <set-if-unset  property="npm.bin" value="npm"/>
 
-   <set-if-exists property="node.bin" value="${node.dir}/bin/node"/>
-   <set-if-exists property="node.bin" value="${node.dir}/node.exe"/>
-   <set-if-unset  property="node.bin" value="node"/>
-
    <target name="testpage" depends="acesupport"
            description="Runs the standalone HTML test pages under test/ in headless chromium">
       <retry retrycount="3">

--- a/src/gwt/src/org/rstudio/core/client/AsyncJavaScriptLoader.java
+++ b/src/gwt/src/org/rstudio/core/client/AsyncJavaScriptLoader.java
@@ -1,0 +1,117 @@
+/*
+ * AsyncJavaScriptLoader.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gwt.user.client.Command;
+
+/**
+ * Loads a collection of JavaScript files, organized into stages: the stages
+ * load one after another, and the scripts within a stage load in parallel.
+ * Each call to add() contributes one stage.
+ *
+ * The underlying ExternalJavaScriptLoaders cache their result, so a loader
+ * can be executed any number of times (and different AsyncJavaScriptLoaders
+ * can share ExternalJavaScriptLoaders); scripts that have already loaded
+ * complete immediately. The onFinished handlers run on every successful
+ * execution, before that execution's own completion command.
+ *
+ * NOTE: as with ExternalJavaScriptLoader, a script that fails to load stalls
+ * the execution silently: neither the onFinished handlers nor the completion
+ * command run.
+ */
+public class AsyncJavaScriptLoader
+{
+   public AsyncJavaScriptLoader add(ExternalJavaScriptLoader... loaders)
+   {
+      List<ExternalJavaScriptLoader> stage = new ArrayList<>();
+      for (ExternalJavaScriptLoader loader : loaders)
+         stage.add(loader);
+
+      if (!stage.isEmpty())
+         stages_.add(stage);
+
+      return this;
+   }
+
+   public AsyncJavaScriptLoader add(String... urls)
+   {
+      ExternalJavaScriptLoader[] loaders = new ExternalJavaScriptLoader[urls.length];
+      for (int i = 0; i < urls.length; i++)
+         loaders[i] = new ExternalJavaScriptLoader(urls[i]);
+
+      return add(loaders);
+   }
+
+   public AsyncJavaScriptLoader onFinished(Command command)
+   {
+      onFinished_.add(command);
+      return this;
+   }
+
+   public boolean isLoaded()
+   {
+      for (List<ExternalJavaScriptLoader> stage : stages_)
+         for (ExternalJavaScriptLoader loader : stage)
+            if (!loader.isLoaded())
+               return false;
+
+      return true;
+   }
+
+   public void execute()
+   {
+      execute(null);
+   }
+
+   public void execute(Command onCompleted)
+   {
+      executeStage(0, onCompleted);
+   }
+
+   private void executeStage(int index, Command onCompleted)
+   {
+      if (index == stages_.size())
+      {
+         for (Command command : onFinished_)
+            command.execute();
+
+         if (onCompleted != null)
+            onCompleted.execute();
+
+         return;
+      }
+
+      List<ExternalJavaScriptLoader> stage = stages_.get(index);
+
+      // the counter is local so that concurrent executions don't share state;
+      // the underlying loaders coalesce the actual script loads
+      final int[] pending = { stage.size() };
+      ExternalJavaScriptLoader.Callback onLoaded = () ->
+      {
+         pending[0] -= 1;
+         if (pending[0] == 0)
+            executeStage(index + 1, onCompleted);
+      };
+
+      for (ExternalJavaScriptLoader loader : stage)
+         loader.addCallback(onLoaded);
+   }
+
+   private final List<List<ExternalJavaScriptLoader>> stages_ = new ArrayList<>();
+   private final List<Command> onFinished_ = new ArrayList<>();
+}

--- a/src/gwt/src/org/rstudio/core/client/StartupTiming.java
+++ b/src/gwt/src/org/rstudio/core/client/StartupTiming.java
@@ -1,0 +1,43 @@
+/*
+ * StartupTiming.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+/**
+ * Records client startup milestones as User Timing marks ("rstudio:&lt;name&gt;").
+ * The marks show up in the browser's Performance panel, and RStudio Desktop
+ * harvests them into the RSTUDIO_STARTUP_TIMING file alongside its own and
+ * the R session's checkpoints (see tasks/startup-timing.ts).
+ */
+public class StartupTiming
+{
+   public static native void mark(String name) /*-{
+      if ($wnd.performance && $wnd.performance.mark)
+         $wnd.performance.mark("rstudio:" + name);
+   }-*/;
+
+   /**
+    * Records a mark once the browser has painted the frame following the
+    * current one; used to approximate when a just-attached UI is visible.
+    */
+   public static native void markAfterPaint(String name) /*-{
+      if (!$wnd.requestAnimationFrame)
+         return;
+      $wnd.requestAnimationFrame(function() {
+         $wnd.setTimeout(function() {
+            @org.rstudio.core.client.StartupTiming::mark(Ljava/lang/String;)(name);
+         }, 0);
+      });
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
@@ -147,10 +147,6 @@ public class RpcRequest
                      requestLogEntry_.logResponse(ResponseType.Normal,
                                                  responseText);
                      rpcResponse = RpcResponse.parseUnsafe(responseText);
-                     
-                     // response received and validated, process it!
-                     requestCallback.onResponseReceived(enclosingRequest, 
-                                                        rpcResponse);
                   }
                   catch(Exception e)
                   {
@@ -159,7 +155,16 @@ public class RpcRequest
                                                 RpcError.TRANSMISSION_ERROR,
                                                 e.getLocalizedMessage());
                      requestCallback.onError(enclosingRequest, error);
+                     return;
                   }
+
+                  // response received and validated, process it! NOTE: this is
+                  // deliberately outside the try/catch above: an exception from
+                  // the callback is a client bug, and catching it here would
+                  // both misreport it as a transmission error and hide it from
+                  // the uncaught-exception log
+                  requestCallback.onResponseReceived(enclosingRequest,
+                                                     rpcResponse);
                }
                else
                {

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
@@ -158,6 +158,17 @@ public class RpcRequest
                      return;
                   }
 
+                  // parse failures are reported as a null response rather
+                  // than an exception
+                  if (rpcResponse == null)
+                  {
+                     RpcError error = RpcError.create(
+                                                RpcError.TRANSMISSION_ERROR,
+                                                "Unable to parse the response from the server");
+                     requestCallback.onError(enclosingRequest, error);
+                     return;
+                  }
+
                   // response received and validated, process it! NOTE: this is
                   // deliberately outside the try/catch above: an exception from
                   // the callback is a client bug, and catching it here would

--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -125,6 +125,13 @@
    <!--<set-configuration-property name="CssResource.style" value="pretty" />-->
    <set-configuration-property name="UiBinder.useSafeHtmlTemplates" value="true" />
 
+   <!-- Install the initial fragment via a script tag instead of eval of
+        downloaded strings; script tags let the browser compile the code in
+        a background thread during the download, and reuse its compiled-code
+        cache across page loads (we always serve same-origin, which this
+        install mode requires) -->
+   <set-configuration-property name="installCode" value="false"/>
+
    <!-- work around incompatibility between GWT 2.8 and Gin 2.1.2 -->
    <set-configuration-property name="gin.classloading.exceptedPackages" value="com.google.gwt.core.client"/>
 

--- a/src/gwt/src/org/rstudio/studio/RStudioDesktopSuperDevMode.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudioDesktopSuperDevMode.gwt.xml
@@ -4,6 +4,11 @@
    <inherits name="org.rstudio.studio.RStudio" />
    <set-property name="compiler.stackMode" value="native"/>
    <set-property name="rstudio.desktop" value="true"/>
+
+   <!-- the base module uses a script-tag install (installCode=false), which
+        requires same-origin scripts; Super Dev Mode serves code from the code
+        server on another origin, so restore the default install here -->
+   <set-configuration-property name="installCode" value="true"/>
    <!-- dev language for i18n development -->
    <extend-property name="locale" values="en,fr,dev"/>
    <!--<set-property name="locale" value="dev"/>-->

--- a/src/gwt/src/org/rstudio/studio/RStudioSuperDevMode.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudioSuperDevMode.gwt.xml
@@ -12,6 +12,11 @@
    <inherits name="org.rstudio.studio.RStudio" />
    <set-property name="compiler.stackMode" value="native"/>
    <set-property name="user.agent" value="safari"/>
+
+   <!-- the base module uses a script-tag install (installCode=false), which
+        requires same-origin scripts; Super Dev Mode serves code from the code
+        server on another origin, so restore the default install here -->
+   <set-configuration-property name="installCode" value="true"/>
    <!-- dev language for i18n development -->
    <extend-property name="locale" values="en,fr,dev"/>
    <!--<set-property name="locale" value="dev"/>-->

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.StartupTiming;
 import org.rstudio.core.client.SerializedCommandQueue;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.LinkColumn;
@@ -126,6 +127,7 @@ public class RStudio implements EntryPoint
 {
    public void onModuleLoad()
    {
+      StartupTiming.mark("module-load");
       Debug.injectDebug();
       maybeSetWindowName("rstudio-" + StringUtil.makeRandomId(16));
       maybeDelayLoadApplication(this);
@@ -275,6 +277,11 @@ public class RStudio implements EntryPoint
 
       // ensure Ace is loaded up front
       queue.addCommand(continuation -> AceEditor.load(continuation));
+      queue.addCommand(continuation ->
+      {
+         StartupTiming.mark("ace-loaded");
+         continuation.execute();
+      });
 
       // load the requested page
       queue.addCommand(continuation -> onDelayLoadApplication());
@@ -284,6 +291,7 @@ public class RStudio implements EntryPoint
          @Override
          public void onSuccess()
          {
+            StartupTiming.mark("app-fragment-loaded");
             queue.run();
          }
 
@@ -299,6 +307,7 @@ public class RStudio implements EntryPoint
    private void onDelayLoadApplication()
    {
       ensureStylesInjected();
+      StartupTiming.mark("styles-injected");
 
       String view = Window.Location.getParameter("view");
       if (VCSApplication.NAME.equals(view))

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -275,16 +275,38 @@ public class RStudio implements EntryPoint
 
       final SerializedCommandQueue queue = new SerializedCommandQueue();
 
-      // ensure Ace is loaded up front
-      queue.addCommand(continuation -> AceEditor.load(continuation));
-      queue.addCommand(continuation ->
+      if (StringUtil.isNullOrEmpty(view))
       {
-         StartupTiming.mark("ace-loaded");
-         continuation.execute();
-      });
+         // in the main window, start the application first: it sends the
+         // client_init request immediately, and Ace then loads while that
+         // round trip is in flight (the workbench is not built until both
+         // have finished; see Application.go)
+         queue.addCommand(continuation ->
+         {
+            onDelayLoadApplication();
+            continuation.execute();
+         });
 
-      // load the requested page
-      queue.addCommand(continuation -> onDelayLoadApplication());
+         queue.addCommand(continuation -> AceEditor.load(continuation));
+         queue.addCommand(continuation ->
+         {
+            StartupTiming.mark("ace-loaded");
+            continuation.execute();
+         });
+      }
+      else
+      {
+         // satellites construct editors as soon as they open, so they need
+         // Ace loaded up front
+         queue.addCommand(continuation -> AceEditor.load(continuation));
+         queue.addCommand(continuation ->
+         {
+            StartupTiming.mark("ace-loaded");
+            continuation.execute();
+         });
+
+         queue.addCommand(continuation -> onDelayLoadApplication());
+      }
 
       GWT.runAsync(new RunAsyncCallback()
       {

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -94,6 +94,7 @@ import org.rstudio.studio.client.workbench.prefs.model.UserState;
 import org.rstudio.studio.client.workbench.prefs.model.WebDialogCookie;
 import org.rstudio.studio.client.workbench.views.environment.events.MemoryUsageChangedEvent;
 import org.rstudio.studio.client.workbench.views.environment.model.MemoryUsage;
+import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Document;
@@ -289,7 +290,11 @@ public class Application implements ApplicationEventHandlers
                      ApplicationAutomation automation = pAutomation_.get();
                      automation.initializeAgent();
                   }
-                  initializeWorkbench();
+
+                  // client_init was sent while Ace was still loading; the
+                  // workbench constructs editors (console input, source), so
+                  // wait for Ace before building it (a no-op if already loaded)
+                  AceEditor.load(() -> initializeWorkbench());
                });
             });
          }

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -267,17 +267,18 @@ public class Application implements ApplicationEventHandlers
                };
             }
 
-            // refresh prefs in case they were loaded without sessionInfo (this
-            // happens exclusively in desktop mode, though unsure why). The
-            // refresh is the synchronous first step of writeState() and
-            // writeUserPrefs(), so the automation agent and the workbench see
-            // a complete pref set (registerPrefs() iterates
-            // userPrefs_.allPrefs()) without waiting for the set_user_state /
-            // set_user_prefs round trips, which only write these same values
-            // back to the server. Failures there are logged but must not block
-            // or dead-end startup (see #18019).
-            userState_.get().writeState(null);
-            userPrefs_.get().writeUserPrefs(null);
+            // UserPrefs can be constructed before this response arrives
+            // (eager GIN singletons and the application headers inject it
+            // during Application construction), leaving its pref layers
+            // empty. Refresh prefs and state from the session info so
+            // everything downstream -- in particular the automation agent,
+            // whose registerPrefs() iterates userPrefs_.allPrefs() -- sees
+            // complete values. No server write-back is needed: these are the
+            // same values the server just sent us, and echoing them via
+            // writeUserPrefs()/writeState() would rewrite the pref and state
+            // files on every load.
+            userPrefs_.get().loadFromSessionInfo();
+            userState_.get().loadFromSessionInfo();
 
             if (sessionInfo.isAutomationAgent())
             {

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -239,10 +239,6 @@ public class Application implements ApplicationEventHandlers
                   }
                }.schedule(10000);
             }
-            else
-            {
-               dismissLoadingProgress.execute();
-            }
 
             // set session info
             session_.setSessionInfo(sessionInfo);
@@ -292,7 +288,16 @@ public class Application implements ApplicationEventHandlers
             // client_init was sent while Ace was still loading; the
             // workbench constructs editors (console input, source), so
             // wait for Ace before building it (a no-op if already loaded)
-            AceEditor.load(() -> initializeWorkbench());
+            AceEditor.load(() ->
+            {
+               // dismiss the loading UI only now, so a client_init response
+               // that beats the ace load doesn't expose a blank shell
+               // (switch-project keeps its overlay on the timer above)
+               if (!ApplicationAction.isSwitchProject())
+                  dismissLoadingProgress.execute();
+
+               initializeWorkbench();
+            });
          }
 
          public void onError(ServerError error)

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -271,32 +271,28 @@ public class Application implements ApplicationEventHandlers
                };
             }
 
-            // initialize workbench
-            // refresh prefs incase they were loaded without sessionInfo (this happens exclusively
-            // in desktop mode, though unsure why). The automation agent must be initialized
-            // after this refresh -- registerPrefs() iterates userPrefs_.allPrefs(), and in desktop
-            // mode that returns an incomplete set until the pref refresh has run.
-            // The completion booleans report whether the set_user_state /
-            // set_user_prefs RPCs succeeded, but we deliberately proceed to
-            // build the workbench either way: a transient persistence failure
-            // here must not dead-end startup (see #18019). The RPC error has
-            // already been logged by writeState()/writeUserPrefs().
-            userState_.get().writeState(boolArg ->
-            {
-               userPrefs_.get().writeUserPrefs(boolArg1 ->
-               {
-                  if (sessionInfo.isAutomationAgent())
-                  {
-                     ApplicationAutomation automation = pAutomation_.get();
-                     automation.initializeAgent();
-                  }
+            // refresh prefs in case they were loaded without sessionInfo (this
+            // happens exclusively in desktop mode, though unsure why). The
+            // refresh is the synchronous first step of writeState() and
+            // writeUserPrefs(), so the automation agent and the workbench see
+            // a complete pref set (registerPrefs() iterates
+            // userPrefs_.allPrefs()) without waiting for the set_user_state /
+            // set_user_prefs round trips, which only write these same values
+            // back to the server. Failures there are logged but must not block
+            // or dead-end startup (see #18019).
+            userState_.get().writeState(null);
+            userPrefs_.get().writeUserPrefs(null);
 
-                  // client_init was sent while Ace was still loading; the
-                  // workbench constructs editors (console input, source), so
-                  // wait for Ace before building it (a no-op if already loaded)
-                  AceEditor.load(() -> initializeWorkbench());
-               });
-            });
+            if (sessionInfo.isAutomationAgent())
+            {
+               ApplicationAutomation automation = pAutomation_.get();
+               automation.initializeAgent();
+            }
+
+            // client_init was sent while Ace was still loading; the
+            // workbench constructs editors (console input, source), so
+            // wait for Ace before building it (a no-op if already loaded)
+            AceEditor.load(() -> initializeWorkbench());
          }
 
          public void onError(ServerError error)

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.Barrier;
 import org.rstudio.core.client.Barrier.Token;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.StartupTiming;
 import org.rstudio.core.client.DragDropReceiver;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -206,6 +207,7 @@ public class Application implements ApplicationEventHandlers
                   final Command dismissLoadingProgress,
                   final ServerRequestCallback<String> connectionStatusCallback)
    {
+      StartupTiming.mark("application-go");
       rootPanel_ = rootPanel;
 
       Widget w = view_.getWidget();
@@ -218,6 +220,7 @@ public class Application implements ApplicationEventHandlers
 
          public void onResponseReceived(final SessionInfo sessionInfo)
          {
+            StartupTiming.mark("client-init-received");
             // initialize workbench
             // if this is a switch project then wait to dismiss the
             // loading progress animation for 10 seconds. typically
@@ -1109,6 +1112,8 @@ public class Application implements ApplicationEventHandlers
          return;
       }
 
+      StartupTiming.mark("workbench-init-begin");
+
       // Initialize application theme system
       pAppThemes_.get().initializeThemes(rootPanel_.getElement());
       
@@ -1128,7 +1133,9 @@ public class Application implements ApplicationEventHandlers
 
       // create workbench
       Workbench wb = workbench_.get();
+      StartupTiming.mark("workbench-created");
       eventBusProvider_.get().fireEvent(new SessionInitEvent());
+      StartupTiming.mark("session-init-fired");
 
       // disable commands
       SessionInfo sessionInfo = session_.getSessionInfo();
@@ -1274,6 +1281,8 @@ public class Application implements ApplicationEventHandlers
 
       // show workbench
       view_.showWorkbenchView(wb.getMainView().asWidget());
+      StartupTiming.mark("workbench-attached");
+      StartupTiming.markAfterPaint("workbench-painted");
 
       // hide zoom in and zoom out in web mode
       if (!Desktop.hasDesktopFrame())

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -162,6 +162,17 @@ public class ApplicationAutomation
 
    public final void initializeAgent()
    {
+      // Tripwire for construction-order regressions: the pref layers must be
+      // loaded from the session info before the bridge enumerates them, or
+      // every pref registers with its default value (see #17733). A plain
+      // Java assert would be compiled out of the optimized GWT output that
+      // automation runs against, so check explicitly.
+      if (!userPrefs_.hasLoadedLayers())
+      {
+         throw new IllegalStateException(
+               "automation agent initialized before user prefs were loaded from session info");
+      }
+
       isAutomationAgent_ = true;
       initializeRoot();
       registerCommands();

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -167,7 +167,7 @@ public class ApplicationAutomation
       // every pref registers with its default value (see #17733). A plain
       // Java assert would be compiled out of the optimized GWT output that
       // automation runs against, so check explicitly.
-      if (!userPrefs_.hasLoadedLayers())
+      if (!userPrefs_.hasLoadedLayers(UserPrefs.LAYER_USER))
       {
          throw new IllegalStateException(
                "automation agent initialized before user prefs were loaded from session info");

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationClientInit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationClientInit.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.application;
 
+import org.rstudio.core.client.StartupTiming;
 import org.rstudio.studio.client.application.model.ApplicationServerOperations;
 import org.rstudio.studio.client.application.model.SessionInitOptions;
 import org.rstudio.studio.client.application.ui.RTimeoutOptions;
@@ -97,6 +98,7 @@ public class ApplicationClientInit implements RTimeoutOptions.RTimeoutObserver
          }
       };
 
+      StartupTiming.mark("client-init-sent");
       server_.clientInit(GWT.getHostPageBaseURL(), options, rpcRequestCallback_);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.StartupTiming;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppMenuBar;
 import org.rstudio.core.client.command.CommandBinder;
@@ -147,6 +148,7 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          {
             public void execute()
             {
+               StartupTiming.mark("workbench-initialized");
                Desktop.getFrame().onWorkbenchInitialized(
                      StringUtil.notNull(sessionInfo.getScratchDir()));
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Size;
+import org.rstudio.core.client.StartupTiming;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.TimeBufferedCommand;
 import org.rstudio.core.client.command.AppCommand;
@@ -271,6 +272,7 @@ public class Workbench implements BusyEvent.Handler,
 
    public void onDeferredInitCompleted(DeferredInitCompletedEvent event)
    {
+      StartupTiming.mark("deferred-init-completed");
       session_.updateSessionInfo(event.getData());
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
@@ -572,12 +572,23 @@ public abstract class Prefs
       return val;
    }
    
-   // Meant to be called when the satellite window receives the sessionInfo.
+   // Meant to be called when a window (main or satellite) receives the
+   // sessionInfo.
    protected void updatePrefs(JsArray<PrefLayer> layers)
    {
       layers_ = layers;
    }
-   
+
+   /**
+    * Indicates whether preference layers have been loaded. Prefs objects
+    * constructed before the session info arrives start with no layers, and
+    * every preference reads as its default until updatePrefs() supplies them.
+    */
+   public boolean hasLoadedLayers()
+   {
+      return layers_.length() > 0;
+   }
+
    private JsArray<PrefLayer> layers_;
    private final HashMap<String, PrefValue<?>> values_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
@@ -586,7 +586,16 @@ public abstract class Prefs
     */
    public boolean hasLoadedLayers()
    {
-      return layers_.length() > 0;
+      if (layers_.length() == 0)
+         return false;
+
+      // SessionInfo synthesizes a placeholder layer ([{}]) when the session
+      // never delivered prefs; only layers the session built carry values
+      for (int i = 0; i < layers_.length(); i++)
+         if (layers_.get(i).getValues() == null)
+            return false;
+
+      return true;
    }
 
    private JsArray<PrefLayer> layers_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
@@ -580,13 +580,19 @@ public abstract class Prefs
    }
 
    /**
-    * Indicates whether preference layers have been loaded. Prefs objects
-    * constructed before the session info arrives start with no layers, and
-    * every preference reads as its default until updatePrefs() supplies them.
+    * Indicates whether preference layers have been loaded, up to and
+    * including the given layer. Prefs objects constructed before the session
+    * info arrives start with no layers, and every preference reads as its
+    * default until updatePrefs() supplies them.
+    *
+    * @param requiredLayer The highest layer index that must be present
+    *   (e.g. UserPrefs.LAYER_USER).
     */
-   public boolean hasLoadedLayers()
+   public boolean hasLoadedLayers(int requiredLayer)
    {
-      if (layers_.length() == 0)
+      // the layer array can be shorter than the fixed layer indices during
+      // startup (see SessionInfo's clamped accessors)
+      if (layers_.length() <= requiredLayer)
          return false;
 
       // SessionInfo synthesizes a placeholder layer ([{}]) when the session

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -104,6 +104,19 @@ public class UserPrefs extends UserPrefsComputed
       }
    }
 
+   /**
+    * Reloads the preference layers from the session info.
+    *
+    * UserPrefs can be constructed before the client_init response arrives
+    * (eager GIN singletons and the application headers inject it during
+    * application startup), in which case the layers start out empty and every
+    * preference reads as its default until this is called.
+    */
+   public void loadFromSessionInfo()
+   {
+      updatePrefs(session_.getSessionInfo().getPrefs());
+   }
+
    public void writeUserPrefs()
    {
       writeUserPrefs(null);
@@ -127,7 +140,7 @@ public class UserPrefs extends UserPrefsComputed
    // ambiguous, since CommandWithArg and CommandWith2Args are unrelated types.
    public void writeUserPrefsWithDetail(CommandWith2Args<Boolean, String> onCompleted)
    {
-      updatePrefs(session_.getSessionInfo().getPrefs());
+      loadFromSessionInfo();
       server_.setUserPrefs(
          session_.getSessionInfo().getUserPrefs(),
          new ServerRequestCallback<VoidResponse>()
@@ -279,7 +292,7 @@ public class UserPrefs extends UserPrefsComputed
    @Override
    public void onSessionInit(SessionInitEvent event)
    {
-      updatePrefs(session_.getSessionInfo().getPrefs());
+      loadFromSessionInfo();
 
       origScreenReaderLabel_ = commands_.toggleScreenReaderSupport().getMenuLabel(false);
       announceScreenReaderState();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserState.java
@@ -51,6 +51,18 @@ public class UserState extends UserStateAccessor implements UserStateChangedEven
       eventBus.addHandler(UserStateChangedEvent.TYPE, this);
    }
    
+   /**
+    * Reloads the state layers from the session info.
+    *
+    * See UserPrefs.loadFromSessionInfo(); unlike UserPrefs, UserState is not
+    * normally constructed until after the session info arrives, so this is
+    * primarily insurance against construction-order changes.
+    */
+   public void loadFromSessionInfo()
+   {
+      updatePrefs(session_.getSessionInfo().getUserState());
+   }
+
    public void writeState()
    {
       writeState(null);
@@ -58,7 +70,7 @@ public class UserState extends UserStateAccessor implements UserStateChangedEven
 
    public void writeState(CommandWithArg<Boolean> onCompleted)
    {
-      updatePrefs(session_.getSessionInfo().getUserState());
+      loadFromSessionInfo();
       server_.setUserState(
          session_.getSessionInfo().getUserStateLayer().getValues(),
          new ServerRequestCallback<VoidResponse>() 
@@ -88,8 +100,8 @@ public class UserState extends UserStateAccessor implements UserStateChangedEven
             public void onError(ServerError error)
             {
                // still invoke the continuation on failure so that callers
-               // chaining off writeState() (e.g. workbench bootstrap) are not
-               // left dead-ended by a transient RPC failure (see #18019)
+               // chaining off writeState() are not left dead-ended by a
+               // transient RPC failure (see #18019)
                if (onCompleted != null)
                {
                   onCompleted.execute(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -169,6 +169,12 @@ public class ConsolePane extends WorkbenchPane
 
    public int getCharacterWidth()
    {
+      // the shell is created alongside the pane's widget; a measurement can
+      // be requested before then (e.g. a font-size change during startup),
+      // and 0 means "no valid measurement yet" to consumers
+      if (shell_ == null)
+         return 0;
+
       return shell_.getDisplay().getCharacterWidth();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -575,8 +575,9 @@ public class Source implements InsertSourceEvent.Handler,
          openEditPublishedDocs();
       }
 
-      // add vim commands
-      columnManager_.initVimCommands();
+      // add vim commands once the vim keybindings load (they load lazily,
+      // requested by the first editor that uses them)
+      AceEditor.onKeybindingsLoaded(() -> columnManager_.initVimCommands());
    }
 
    private void loadFullSource()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -23,6 +23,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 
 import org.rstudio.core.client.AceSupport;
+import org.rstudio.core.client.AsyncJavaScriptLoader;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
@@ -302,33 +303,14 @@ public class AceEditor implements DocDisplay
 
    public static void load(final Command command)
    {
-      // the vim / emacs keybindings are not part of the base load; they are
-      // loaded lazily, by the first editor that needs them (loadKeybindings)
-      aceLoader_.addCallback(() ->
-      {
-         // acesupport and ext-language-tools depend only on ace itself, so
-         // load them in parallel
-         final int[] pending = { 2 };
-         ExternalJavaScriptLoader.Callback onLoaded = () ->
-         {
-            pending[0] -= 1;
-            if (pending[0] > 0)
-               return;
-
-            AceSupport.initialize();
-
-            if (command != null)
-               command.execute();
-         };
-
-         aceSupportLoader_.addCallback(onLoaded);
-         extLanguageToolsLoader_.addCallback(onLoaded);
-      });
+      // NOTE: the vim / emacs keybindings are not part of the base load; they
+      // are loaded lazily, by the first editor that needs them (loadKeybindings)
+      baseLoader_.execute(command);
    }
 
    public static boolean keybindingsLoaded()
    {
-      return vimLoader_.isLoaded() && emacsLoader_.isLoaded();
+      return keybindingsLoader_.isLoaded();
    }
 
    // Run a command once the vim / emacs keybindings have loaded, without
@@ -344,20 +326,7 @@ public class AceEditor implements DocDisplay
 
    public static void loadKeybindings(final Command command)
    {
-      aceLoader_.addCallback(() ->
-            vimLoader_.addCallback(() ->
-                  emacsLoader_.addCallback(() ->
-                  {
-                     AceEditorNative.fixupEmacsKeybindings();
-                     TextEditingTarget.initializeIncrementalSearch();
-
-                     for (Command pendingCommand : keybindingsLoadedCommands_)
-                        pendingCommand.execute();
-                     keybindingsLoadedCommands_.clear();
-
-                     if (command != null)
-                        command.execute();
-                  })));
+      keybindingsLoader_.execute(command);
    }
 
    public static final native AceEditor getEditor(Element el)
@@ -5237,6 +5206,29 @@ public class AceEditor implements DocDisplay
                    AceResources.INSTANCE.extLanguageToolsUncompressed());
 
    private static final List<Command> keybindingsLoadedCommands_ = new ArrayList<>();
+
+   // ace itself must load before the bundles extending it; within each stage
+   // the scripts load in parallel
+   private static final AsyncJavaScriptLoader baseLoader_ =
+         new AsyncJavaScriptLoader()
+               .add(aceLoader_)
+               .add(aceSupportLoader_, extLanguageToolsLoader_)
+               .onFinished(() -> AceSupport.initialize());
+
+   private static final AsyncJavaScriptLoader keybindingsLoader_ =
+         new AsyncJavaScriptLoader()
+               .add(aceLoader_)
+               .add(vimLoader_, emacsLoader_)
+               .onFinished(() ->
+               {
+                  // setup that piggybacks on the keybindings' arrival
+                  AceEditorNative.fixupEmacsKeybindings();
+                  TextEditingTarget.initializeIncrementalSearch();
+
+                  for (Command pendingCommand : keybindingsLoadedCommands_)
+                     pendingCommand.execute();
+                  keybindingsLoadedCommands_.clear();
+               });
 
    private boolean popupVisible_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -302,21 +302,62 @@ public class AceEditor implements DocDisplay
 
    public static void load(final Command command)
    {
+      // the vim / emacs keybindings are not part of the base load; they are
+      // loaded lazily, by the first editor that needs them (loadKeybindings)
       aceLoader_.addCallback(() ->
-            aceSupportLoader_.addCallback(() ->
-                  extLanguageToolsLoader_.addCallback(() ->
-                        vimLoader_.addCallback(() ->
-                              emacsLoader_.addCallback(() ->
-                              {
-                                 AceSupport.initialize();
+      {
+         // acesupport and ext-language-tools depend only on ace itself, so
+         // load them in parallel
+         final int[] pending = { 2 };
+         ExternalJavaScriptLoader.Callback onLoaded = () ->
+         {
+            pending[0] -= 1;
+            if (pending[0] > 0)
+               return;
 
-                                 if (command != null)
-                                    command.execute();
-                              })
-                        )
-                  )
-            )
-      );
+            AceSupport.initialize();
+
+            if (command != null)
+               command.execute();
+         };
+
+         aceSupportLoader_.addCallback(onLoaded);
+         extLanguageToolsLoader_.addCallback(onLoaded);
+      });
+   }
+
+   public static boolean keybindingsLoaded()
+   {
+      return vimLoader_.isLoaded() && emacsLoader_.isLoaded();
+   }
+
+   // Run a command once the vim / emacs keybindings have loaded, without
+   // triggering the load itself. Used for setup (like the vim ex commands)
+   // that is only meaningful once some editor has requested the keybindings.
+   public static void onKeybindingsLoaded(final Command command)
+   {
+      if (keybindingsLoaded())
+         command.execute();
+      else
+         keybindingsLoadedCommands_.add(command);
+   }
+
+   public static void loadKeybindings(final Command command)
+   {
+      aceLoader_.addCallback(() ->
+            vimLoader_.addCallback(() ->
+                  emacsLoader_.addCallback(() ->
+                  {
+                     AceEditorNative.fixupEmacsKeybindings();
+                     TextEditingTarget.initializeIncrementalSearch();
+
+                     for (Command pendingCommand : keybindingsLoadedCommands_)
+                        pendingCommand.execute();
+                     keybindingsLoadedCommands_.clear();
+
+                     if (command != null)
+                        command.execute();
+                  })));
    }
 
    public static final native AceEditor getEditor(Element el)
@@ -1135,6 +1176,15 @@ public class AceEditor implements DocDisplay
 
    private void updateKeyboardHandlers()
    {
+      // the vim / emacs keybindings load lazily; if they are needed here but
+      // not yet available, apply the handlers once they arrive (the editor
+      // keeps default keybindings in the interim)
+      if ((useVimMode_ || useEmacsKeybindings_) && !keybindingsLoaded())
+      {
+         loadKeybindings(() -> updateKeyboardHandlers());
+         return;
+      }
+
       // clear out existing keyboard handlers (they will be refreshed below)
       for (HandlerRegistration handler : keyboardHandlers_)
          if (handler != null)
@@ -5185,6 +5235,8 @@ public class AceEditor implements DocDisplay
    private static final ExternalJavaScriptLoader extLanguageToolsLoader_ =
          getLoader(AceResources.INSTANCE.extLanguageTools(),
                    AceResources.INSTANCE.extLanguageToolsUncompressed());
+
+   private static final List<Command> keybindingsLoadedCommands_ = new ArrayList<>();
 
    private boolean popupVisible_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1145,15 +1145,6 @@ public class AceEditor implements DocDisplay
 
    private void updateKeyboardHandlers()
    {
-      // the vim / emacs keybindings load lazily; if they are needed here but
-      // not yet available, apply the handlers once they arrive (the editor
-      // keeps default keybindings in the interim)
-      if ((useVimMode_ || useEmacsKeybindings_) && !keybindingsLoaded())
-      {
-         loadKeybindings(() -> updateKeyboardHandlers());
-         return;
-      }
-
       // clear out existing keyboard handlers (they will be refreshed below)
       for (HandlerRegistration handler : keyboardHandlers_)
          if (handler != null)
@@ -1171,8 +1162,17 @@ public class AceEditor implements DocDisplay
       // create a keyboard previewer for our special hooks
       AceKeyboardPreviewer previewer = new AceKeyboardPreviewer(completionManager_);
 
-      // set default key handler
-      if (useVimMode_)
+      // set default key handler. the vim / emacs keybindings load lazily; if
+      // they are needed here but not yet available, keep default keybindings
+      // and re-run once they arrive -- only this choice of handler waits on
+      // them, so the previewer and event listeners below stay installed in
+      // the interim (and permanently, should the load fail)
+      if ((useVimMode_ || useEmacsKeybindings_) && !keybindingsLoaded())
+      {
+         loadKeybindings(() -> updateKeyboardHandlers());
+         widget_.getEditor().setKeyboardHandler(null);
+      }
+      else if (useVimMode_)
       {
          widget_.getEditor().setKeyboardHandler(KeyboardHandler.vim());
          RStudioGinjector.INSTANCE.getVimrcLoader().ensureLoaded(widget_.getEditor());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -645,25 +645,30 @@ public class AceEditorWidget extends Composite
          remapForEditImpl("<C-S-v>", "c-s-v");
    }
 
+   // NOTE: the vim / emacs keybindings load lazily, so either module can be
+   // absent here; nothing needs unmapping until it loads
    private static final native void unmapForEditImpl(String vimKeys, String emacsKeys)
    /*-{
 
       // Handle Vim mapping
-      var Vim = $wnd.require("ace/keyboard/vim").handler;
-      var keymap = Vim.defaultKeymap;
-      for (var i = 0; i < keymap.length; i++) {
-         if (keymap[i].keys === vimKeys) {
-            keymap[i].keys = "DISABLED:" + vimKeys;
-            break;
+      var vimModule = $wnd.require("ace/keyboard/vim");
+      if (vimModule) {
+         var keymap = vimModule.handler.defaultKeymap;
+         for (var i = 0; i < keymap.length; i++) {
+            if (keymap[i].keys === vimKeys) {
+               keymap[i].keys = "DISABLED:" + vimKeys;
+               break;
+            }
          }
       }
 
       // Handle Emacs mapping
-      var Emacs = $wnd.require("ace/keyboard/emacs").handler;
-      var bindings = Emacs.commandKeyBinding;
-      bindings["DISABLED:" + emacsKeys] = bindings[emacsKeys];
-      delete bindings[emacsKeys];
-
+      var emacsModule = $wnd.require("ace/keyboard/emacs");
+      if (emacsModule) {
+         var bindings = emacsModule.handler.commandKeyBinding;
+         bindings["DISABLED:" + emacsKeys] = bindings[emacsKeys];
+         delete bindings[emacsKeys];
+      }
 
    }-*/;
 
@@ -671,21 +676,25 @@ public class AceEditorWidget extends Composite
    /*-{
 
       // Handle Vim mapping
-      var Vim = $wnd.require("ace/keyboard/vim").handler;
-      var keymap = Vim.defaultKeymap;
-      for (var i = 0; i < keymap.length; i++) {
-         if (keymap[i].keys === "DISABLED:" + vimKeys) {
-            keymap[i].keys = vimKeys;
-            break;
+      var vimModule = $wnd.require("ace/keyboard/vim");
+      if (vimModule) {
+         var keymap = vimModule.handler.defaultKeymap;
+         for (var i = 0; i < keymap.length; i++) {
+            if (keymap[i].keys === "DISABLED:" + vimKeys) {
+               keymap[i].keys = vimKeys;
+               break;
+            }
          }
       }
 
       // Handle Emacs mapping
-      var Emacs = $wnd.require("ace/keyboard/emacs").handler;
-      var bindings = Emacs.commandKeyBinding;
-      if (bindings["DISABLED:" + emacsKeys] != null) {
-         bindings[emacsKeys] = bindings["DISABLED:" + emacsKeys];
-         delete bindings["DISABLED:" + emacsKeys];
+      var emacsModule = $wnd.require("ace/keyboard/emacs");
+      if (emacsModule) {
+         var bindings = emacsModule.handler.commandKeyBinding;
+         if (bindings["DISABLED:" + emacsKeys] != null) {
+            bindings[emacsKeys] = bindings["DISABLED:" + emacsKeys];
+            delete bindings["DISABLED:" + emacsKeys];
+         }
       }
    }-*/;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -905,8 +905,16 @@ public class TextEditingTarget implements
       initializeIncrementalSearch();
    }
 
-   private static final native String initializeIncrementalSearch() /*-{
-      var IncrementalSearch = $wnd.require("ace/incremental_search").IncrementalSearch;
+   // Route incremental-search messages into our status display.
+   // ace/incremental_search is part of the lazily-loaded emacs keybindings,
+   // so this runs both at class initialization (a no-op if they have not
+   // loaded) and again once they arrive (see AceEditor.loadKeybindings).
+   public static final native void initializeIncrementalSearch() /*-{
+      var isearch = $wnd.require("ace/incremental_search");
+      if (isearch == null)
+         return;
+
+      var IncrementalSearch = isearch.IncrementalSearch;
       (function() {
          this.message = $entry(function(msg) {
             @org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget::setIncrementalSearchMessage(Ljava/lang/String;)(msg);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/Vim.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/Vim.java
@@ -21,28 +21,29 @@ public class Vim
    public Vim(AceEditor editor)
    {
       editor_ = editor.getWidget().getEditor();
-      vim_ = VimAPI.get();
    }
-   
+
    public boolean isActive() { return isActive(editor_); }
    private final native boolean isActive(AceEditorNative editor) /*-{
       return editor.$vimModeHandler != null;
    }-*/;
-   
-   public void exitVisualMode() { exitVisualMode(editor_, vim_); }
+
+   // NOTE: VimAPI is resolved at call time, not construction time -- the vim
+   // keybindings load lazily, and the exit* methods only run when vim mode is
+   // active on the editor, which implies the keybindings have loaded
+   public void exitVisualMode() { exitVisualMode(editor_, VimAPI.get()); }
    private final native void exitVisualMode(AceEditorNative editor, VimAPI vim) /*-{
       var vimState = editor.state.cm.state.vim;
       if (vimState.visualMode)
          vim.exitVisualMode(editor.state.cm);
    }-*/;
-   
-   public void exitInsertMode() { exitInsertMode(editor_, vim_); }
+
+   public void exitInsertMode() { exitInsertMode(editor_, VimAPI.get()); }
    private final native void exitInsertMode(AceEditorNative editor, VimAPI vim) /*-{
       var vimState = editor.state.cm.state.vim;
       if (vimState.insertMode)
          vim.exitInsertMode(editor.state.cm);
    }-*/;
-   
+
    private final AceEditorNative editor_;
-   private final VimAPI vim_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -1046,14 +1046,19 @@ public class AceEditorNative extends JavaScriptObject
       this.session.clearSyntheticTokens();
    }-*/;
 
-   private static final native void initialize()
+   // Remove the 'Return' keybinding associated with Emacs.
+   // We attach some custom behaviors to 'Return', and we
+   // don't want Emacs to override those behaviors.
+   // E.g. the 'Continue comment on newline insertion'
+   // preference. The emacs keybindings load lazily, so this runs both at
+   // class initialization (a no-op if they have not loaded) and again once
+   // they arrive (see AceEditor.loadKeybindings).
+   public static final native void fixupEmacsKeybindings()
    /*-{
-      // Remove the 'Return' keybinding associated with Emacs.
-      // We attach some custom behaviors to 'Return', and we
-      // don't want Emacs to override those behaviors.
-      // E.g. the 'Continue comment on newline insertion'
-      // preference.
       var Emacs = $wnd.require("ace/keyboard/emacs");
+      if (Emacs == null)
+         return;
+
       var handler = Emacs.handler || {};
       var bindings = handler.commandKeyBinding || {};
       if (bindings.hasOwnProperty("return")) {
@@ -1073,7 +1078,7 @@ public class AceEditorNative extends JavaScriptObject
       this.renderer.theme = theme;
    }-*/;
 
-   static { initialize(); }
+   static { fixupEmacsKeybindings(); }
 
    private static boolean uiPrefsSynced_ = false;
 }

--- a/src/gwt/tools/precompress.js
+++ b/src/gwt/tools/precompress.js
@@ -27,8 +27,51 @@ const zlib = require('zlib');
 // small files aren't worth a round trip through the decompressor
 const kMinSizeBytes = 4096;
 
-const root = process.argv[2];
-if (!root || !fs.existsSync(root)) {
+// Rebuild the target directory one component at a time from directory
+// listings, so every component of every path handled below is a string
+// returned by fs.readdirSync rather than a substring of the command line.
+// The build pointing this tool at its own output directory is not an attack,
+// but the Snyk Code scan reports the direct data flow as path traversal and
+// offers no way to suppress the finding (see tasks/common.ts for the same
+// dodge). Returns null when the directory does not exist.
+function rebuildFromDirectoryListings(input) {
+  const resolved = path.resolve(input);
+  const parsed = path.parse(resolved);
+
+  // the filesystem root: '/' on POSIX; on Windows, re-derive the drive letter
+  // numerically so the result shares no substring with the input
+  let result;
+  if (parsed.root === '/') {
+    result = '/';
+  } else if (/^[A-Za-z]:[\\/]$/.test(parsed.root)) {
+    result = String.fromCharCode(parsed.root.toUpperCase().charCodeAt(0)) + ':\\';
+  } else {
+    return null;
+  }
+
+  for (const segment of resolved.slice(parsed.root.length).split(/[\\/]+/)) {
+    if (segment.length === 0) {
+      continue;
+    }
+
+    // the case-insensitive fallback covers case-insensitive filesystems
+    // (the macOS and Windows defaults)
+    const entries = fs.readdirSync(result);
+    const entry =
+      entries.find((e) => e === segment) ??
+      entries.find((e) => e.toLowerCase() === segment.toLowerCase());
+    if (entry === undefined) {
+      return null;
+    }
+
+    result = path.join(result, entry);
+  }
+
+  return result;
+}
+
+const root = process.argv[2] ? rebuildFromDirectoryListings(process.argv[2]) : null;
+if (root === null) {
   console.error('usage: node precompress.js <directory>');
   process.exit(1);
 }

--- a/src/gwt/tools/precompress.js
+++ b/src/gwt/tools/precompress.js
@@ -1,0 +1,82 @@
+/*
+ * precompress.js
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+// Writes a gzipped sibling (<file>.gz) next to each large content-hashed GWT
+// build output, so the session can serve Content-Encoding: gzip without
+// paying the deflate cost on every request (see GwtFileHandler.cpp). The
+// hashed files are immutable, so an up-to-date sibling is never regenerated.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+// small files aren't worth a round trip through the decompressor
+const kMinSizeBytes = 4096;
+
+const root = process.argv[2];
+if (!root || !fs.existsSync(root)) {
+  console.error('usage: node precompress.js <directory>');
+  process.exit(1);
+}
+
+let compressed = 0;
+let pruned = 0;
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+      continue;
+    }
+
+    // prune siblings whose source is gone (a rebuild replaced the hash)
+    if (entry.name.endsWith('.gz')) {
+      if (!fs.existsSync(full.slice(0, -3))) {
+        fs.rmSync(full);
+        pruned += 1;
+      }
+      continue;
+    }
+
+    if (!/\.cache\.(js|css)$/.test(entry.name)) {
+      continue;
+    }
+
+    const stat = fs.statSync(full);
+    if (stat.size < kMinSizeBytes) {
+      continue;
+    }
+
+    const gzPath = full + '.gz';
+    let gzStat = null;
+    try {
+      gzStat = fs.statSync(gzPath);
+    } catch {
+      // no sibling yet
+    }
+    if (gzStat && gzStat.mtimeMs >= stat.mtimeMs) {
+      continue;
+    }
+
+    fs.writeFileSync(gzPath, zlib.gzipSync(fs.readFileSync(full), { level: 9 }));
+    compressed += 1;
+  }
+}
+
+walk(root);
+console.log(`precompressed ${compressed} file(s), pruned ${pruned} stale sibling(s) under ${root}`);

--- a/src/node/desktop/src/core/macho.ts
+++ b/src/node/desktop/src/core/macho.ts
@@ -1,0 +1,87 @@
+/*
+ * macho.ts
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { closeSync, openSync, readSync } from 'fs';
+
+// Mach-O header constants (mach-o/loader.h, mach-o/fat.h, mach/machine.h)
+const kMachoMagic32 = 0xfeedface;
+const kMachoMagic64 = 0xfeedfacf;
+const kFatMagic = 0xcafebabe;
+const kFatMagic64 = 0xcafebabf;
+const kFatArchSize = 20;
+const kFatArch64Size = 32;
+
+const kCpuTypeNames = new Map<number, string>([
+  [0x00000007, 'i386'],
+  [0x01000007, 'x86_64'],
+  [0x0000000c, 'arm'],
+  [0x0100000c, 'arm64'],
+]);
+
+function cpuTypeName(cpuType: number): string {
+  return kCpuTypeNames.get(cpuType) ?? `cputype-${cpuType.toString(16)}`;
+}
+
+/**
+ * Architectures contained in a Mach-O image, given its leading bytes. A thin
+ * image yields one entry; a universal ("fat") image yields one per slice.
+ * Returns an empty array for anything that is not Mach-O.
+ */
+export function machoArchitectures(header: Buffer): string[] {
+  if (header.length < 8) {
+    return [];
+  }
+
+  // thin images store the header in the host byte order, which on every
+  // platform Apple ships is little-endian
+  const magicLE = header.readUInt32LE(0);
+  if (magicLE === kMachoMagic32 || magicLE === kMachoMagic64) {
+    return [cpuTypeName(header.readUInt32LE(4))];
+  }
+
+  // fat headers are always big-endian
+  const magicBE = header.readUInt32BE(0);
+  if (magicBE === kFatMagic || magicBE === kFatMagic64) {
+    const entrySize = magicBE === kFatMagic ? kFatArchSize : kFatArch64Size;
+    const count = header.readUInt32BE(4);
+    const architectures: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const offset = 8 + i * entrySize;
+      if (offset + 4 > header.length) {
+        break;
+      }
+      architectures.push(cpuTypeName(header.readUInt32BE(offset)));
+    }
+    return architectures;
+  }
+
+  return [];
+}
+
+/**
+ * Architectures of the Mach-O image at `path`, read from its header. This is
+ * what `/usr/bin/file` reports, without spawning a process for it.
+ */
+export function readMachoArchitectures(path: string): string[] {
+  // large enough for a fat header with any realistic number of slices
+  const header = Buffer.alloc(4096);
+  const fd = openSync(path, 'r');
+  try {
+    const bytes = readSync(fd, header, 0, header.length, 0);
+    return machoArchitectures(header.subarray(0, bytes));
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -25,7 +25,14 @@ import { DesktopActivation } from './activation-overlay';
 import { appState, AppState, getEventBus } from './app-state';
 import { ApplicationLaunch } from './application-launch';
 import { ArgsManager } from './args-manager';
-import { prepareEnvironment, promptUserForR, rDetectionReady, scanForR, showRNotFoundError } from './detect-r';
+import {
+  prepareEnvironment,
+  promptUserForR,
+  rChooserRequested,
+  rDetectionReady,
+  scanForR,
+  showRNotFoundError,
+} from './detect-r';
 import { GwtCallback } from './gwt-callback';
 import { PendingWindow } from './pending-window';
 import { exitFailure, exitSuccess, ProgramStatus, run } from './program-status';
@@ -386,8 +393,13 @@ export class Application implements AppState {
     app.on('window-all-closed', windowAllClosedHandler);
 
     // the query started when the app launched has normally finished by now,
-    // so the detection below finds its answer in the cache
-    await rDetectionReady();
+    // so the detection below finds its answer in the cache. When the Windows
+    // R chooser was explicitly requested, don't wait on the probe: the user
+    // may be choosing a different R precisely because the default one hangs
+    // or fails, and the probe queries that R
+    if (process.platform !== 'win32' || !rChooserRequested()) {
+      await rDetectionReady();
+    }
     startupCheckpoint('r-query-ready');
 
     // on Windows, ask the user what version of R they'd like to use

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -28,7 +28,7 @@ import { ArgsManager } from './args-manager';
 import {
   prepareEnvironment,
   promptUserForR,
-  rChooserRequested,
+  rChooserLikely,
   rDetectionReady,
   scanForR,
   showRNotFoundError,
@@ -394,10 +394,10 @@ export class Application implements AppState {
 
     // the query started when the app launched has normally finished by now,
     // so the detection below finds its answer in the cache. When the Windows
-    // R chooser was explicitly requested, don't wait on the probe: the user
-    // may be choosing a different R precisely because the default one hangs
-    // or fails, and the probe queries that R
-    if (process.platform !== 'win32' || !rChooserRequested()) {
+    // R chooser is going to show anyway (explicitly requested, or a first run
+    // with nothing to reuse), don't wait on the probe: the chooser must not
+    // be delayed by a slow or hanging R
+    if (process.platform !== 'win32' || !rChooserLikely()) {
       await rDetectionReady();
     }
     startupCheckpoint('r-query-ready');

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -32,6 +32,7 @@ import { exitFailure, exitSuccess, ProgramStatus, run } from './program-status';
 import { SatelliteWindow } from './satellite-window';
 import { SecondaryWindow } from './secondary-window';
 import { SessionLauncher } from './session-launcher';
+import { startupCheckpoint } from './startup-timing';
 import {
   augmentCommandLineArguments,
   createStandaloneErrorDialog,
@@ -422,6 +423,7 @@ export class Application implements AppState {
     }
 
     // if we don't have an R path at this point, try scanning for R
+    startupCheckpoint('r-detect-begin');
     if (!rPath) {
       logger().logDebug('No rPath found, scanning for R');
       const [scannedPath, error] = scanForR();
@@ -435,6 +437,7 @@ export class Application implements AppState {
     }
 
     logger().logDebug('Done choosing R');
+    startupCheckpoint('r-detected');
 
     // prepare the R environment
     logger().logDebug(`Preparing environment using R: ${rPath}`);
@@ -444,6 +447,7 @@ export class Application implements AppState {
       await showRNotFoundError();
       return exitFailure();
     }
+    startupCheckpoint('r-environment-prepared');
 
     // launch a local session
     this.sessionLauncher = new SessionLauncher(

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -25,7 +25,7 @@ import { DesktopActivation } from './activation-overlay';
 import { appState, AppState, getEventBus } from './app-state';
 import { ApplicationLaunch } from './application-launch';
 import { ArgsManager } from './args-manager';
-import { prepareEnvironment, promptUserForR, scanForR, showRNotFoundError } from './detect-r';
+import { prepareEnvironment, promptUserForR, rDetectionReady, scanForR, showRNotFoundError } from './detect-r';
 import { GwtCallback } from './gwt-callback';
 import { PendingWindow } from './pending-window';
 import { exitFailure, exitSuccess, ProgramStatus, run } from './program-status';
@@ -384,6 +384,11 @@ export class Application implements AppState {
       // intentionally empty
     };
     app.on('window-all-closed', windowAllClosedHandler);
+
+    // the query started when the app launched has normally finished by now,
+    // so the detection below finds its answer in the cache
+    await rDetectionReady();
+    startupCheckpoint('r-query-ready');
 
     // on Windows, ask the user what version of R they'd like to use
     let rPath;

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -68,6 +68,21 @@ export function rChooserRequested(): boolean {
   return getenv('RSTUDIO_DESKTOP_PROMPT_FOR_R').length !== 0 || desktop.isCtrlKeyDown();
 }
 
+/**
+ * True when Windows startup is going to show the R chooser, as far as can be
+ * predicted without consulting R: explicitly requested, or a first run with
+ * no remembered selection to reuse.
+ */
+export function rChooserLikely(): boolean {
+  if (rChooserRequested()) {
+    return true;
+  }
+  if (getenv('RSTUDIO_WHICH_R').length !== 0) {
+    return false;
+  }
+  return storedRCandidatesWin32().length === 0;
+}
+
 export async function promptUserForR(platform = process.platform): Promise<Expected<string | null>> {
 
   const options = ElectronDesktopOptions();

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -60,12 +60,20 @@ function executeCommand(command: string): Expected<string> {
   });
 }
 
+/**
+ * True when the Windows R chooser was explicitly requested, via the
+ * environment or by holding Ctrl at launch.
+ */
+export function rChooserRequested(): boolean {
+  return getenv('RSTUDIO_DESKTOP_PROMPT_FOR_R').length !== 0 || desktop.isCtrlKeyDown();
+}
+
 export async function promptUserForR(platform = process.platform): Promise<Expected<string | null>> {
 
   const options = ElectronDesktopOptions();
 
   if (platform === 'win32') {
-    const showUi = getenv('RSTUDIO_DESKTOP_PROMPT_FOR_R').length !== 0 || desktop.isCtrlKeyDown();
+    const showUi = rChooserRequested();
 
     if (!showUi) {
       // nothing to do if RSTUDIO_WHICH_R is set

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -212,7 +212,26 @@ function prepareEnvironmentImpl(rPath: string): Err {
   return success();
 }
 
+// Querying R costs a process launch (~150ms or more). The same executable is
+// queried while scanning for installations and again when preparing the
+// session environment, so successful results are remembered per path.
+const rEnvironmentCache = new Map<string, REnvironment>();
+
 export function detectREnvironment(rPath: string): Expected<REnvironment> {
+  const cached = rEnvironmentCache.get(rPath);
+  if (cached) {
+    return ok(cached);
+  }
+
+  const result = detectREnvironmentImpl(rPath);
+  const [environment, error] = result;
+  if (!error) {
+    rEnvironmentCache.set(rPath, environment);
+  }
+  return result;
+}
+
+function detectREnvironmentImpl(rPath: string): Expected<REnvironment> {
   // resolve path to binary if we were given a directory
   let rExecutable = new FilePath(rPath);
   if (rExecutable.isDirectory()) {

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -15,7 +15,7 @@
 
 import path, { join } from 'path';
 
-import { execSync, spawnSync } from 'child_process';
+import { execSync, spawn, spawnSync } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
 
 import { Environment, getenv, setenv, setVars } from '../core/environment';
@@ -75,44 +75,18 @@ export async function promptUserForR(platform = process.platform): Promise<Expec
         return ok(rstudioWhichR);
       }
 
-      // check if user has requested default 32-bit version of R
-      const useDefault32Bit = options.useDefault32BitR();
-      if (useDefault32Bit) {
-        logger().logDebug('User has requested the default 32-bit R installation.');
-        const installPath = findDefault32Bit();
-        if (installPath) {
-          const rPath = `${installPath}/bin/i386/${kWindowsRExe}`;
-          if (existsSync(rPath)) {
-            logger().logDebug(`Using default 32-bit R installation at path: ${rPath}`);
-            return ok(rPath);
-          }
+      for (const candidate of storedRCandidatesWin32()) {
+        if (!candidate.validate) {
+          logger().logDebug(`Using default R installation at path: ${candidate.path}`);
+          return ok(candidate.path);
         }
-      }
 
-      // check if user has requested default 64-bit version of R
-      const useDefault64Bit = options.useDefault64BitR();
-      if (useDefault64Bit) {
-        logger().logDebug('User has requested the default 64-bit R installation.');
-        const installPath = findDefault64Bit();
-        if (installPath) {
-          const rPath = `${installPath}/bin/x64/${kWindowsRExe}`;
-          if (existsSync(rPath)) {
-            logger().logDebug(`Using default 64-bit R installation at path: ${rPath}`);
-            return ok(rPath);
-          }
-        }
-      }
-
-      // otherwise, look for a stored R executable path location
-      const rBinDir = options.rBinDir();
-      if (rBinDir) {
-        const rPath = fixWindowsRExecutablePath(`${rBinDir}/${kWindowsRExe}`);
-        logger().logDebug(`Trying version of R stored in RStudio Desktop options: ${rPath}`);
-        if (isValidBinary(rPath)) {
-          logger().logDebug(`Validation succeeded; using R: ${rPath}`);
-          return ok(rPath);
+        logger().logDebug(`Trying version of R stored in RStudio Desktop options: ${candidate.path}`);
+        if (isValidBinary(candidate.path)) {
+          logger().logDebug(`Validation succeeded; using R: ${candidate.path}`);
+          return ok(candidate.path);
         } else {
-          logger().logDebug(`Validation failed; skipping R: ${rPath}`);
+          logger().logDebug(`Validation failed; skipping R: ${candidate.path}`);
         }
       }
     }
@@ -177,6 +151,75 @@ export async function promptUserForR(platform = process.platform): Promise<Expec
  * // (for example, R_HOME) and other platform-specific work required
  * for R to launch.
  */
+interface RCandidateWin32 {
+  path: string;
+
+  // the defaults recorded in the registry are trusted as they stand; a path
+  // the user stored in the options is checked before use
+  validate: boolean;
+}
+
+/**
+ * The R executables the Windows startup prefers when the user is not asked,
+ * in order: the default 32-bit or 64-bit installation when the options ask
+ * for one (and it exists), then the executable stored in the options.
+ */
+function storedRCandidatesWin32(): RCandidateWin32[] {
+  const options = ElectronDesktopOptions();
+  const candidates: RCandidateWin32[] = [];
+
+  if (options.useDefault32BitR()) {
+    logger().logDebug('User has requested the default 32-bit R installation.');
+    const installPath = findDefault32Bit();
+    if (installPath) {
+      const rPath = `${installPath}/bin/i386/${kWindowsRExe}`;
+      if (existsSync(rPath)) {
+        candidates.push({ path: rPath, validate: false });
+      }
+    }
+  }
+
+  if (options.useDefault64BitR()) {
+    logger().logDebug('User has requested the default 64-bit R installation.');
+    const installPath = findDefault64Bit();
+    if (installPath) {
+      const rPath = `${installPath}/bin/x64/${kWindowsRExe}`;
+      if (existsSync(rPath)) {
+        candidates.push({ path: rPath, validate: false });
+      }
+    }
+  }
+
+  const rBinDir = options.rBinDir();
+  if (rBinDir) {
+    candidates.push({ path: fixWindowsRExecutablePath(`${rBinDir}/${kWindowsRExe}`), validate: true });
+  }
+
+  return candidates;
+}
+
+/**
+ * The default installations recorded in the registry, 64-bit first, as
+ * scanForRWin32 would try them.
+ */
+function registryRCandidatesWin32(): string[] {
+  const candidates: string[] = [];
+
+  if (process.arch === 'x64') {
+    const x64InstallPath = findDefaultInstallPathWin32('R64');
+    if (x64InstallPath) {
+      candidates.push(`${x64InstallPath}/bin/x64/${kWindowsRExe}`);
+    }
+  }
+
+  const i386InstallPath = findDefaultInstallPathWin32('R');
+  if (i386InstallPath) {
+    candidates.push(`${i386InstallPath}/bin/i386/${kWindowsRExe}`);
+  }
+
+  return candidates;
+}
+
 export function prepareEnvironment(rPath: string): Err {
   try {
     return prepareEnvironmentImpl(rPath);
@@ -214,7 +257,9 @@ function prepareEnvironmentImpl(rPath: string): Err {
 
 // Querying R costs a process launch (~150ms or more). The same executable is
 // queried while scanning for installations and again when preparing the
-// session environment, so successful results are remembered per path.
+// session environment, so successful results are remembered per path. The
+// query also runs in the background from the moment the app starts (see
+// startRDetection), which normally fills the cache before anything asks.
 const rEnvironmentCache = new Map<string, REnvironment>();
 
 export function detectREnvironment(rPath: string): Expected<REnvironment> {
@@ -223,7 +268,65 @@ export function detectREnvironment(rPath: string): Expected<REnvironment> {
     return ok(cached);
   }
 
-  const result = detectREnvironmentImpl(rPath);
+  const rExecutable = rExecutableFor(rPath);
+  logger().logDebug(`Querying information about R executable at path: ${rExecutable}`);
+
+  const [spawned, spawnError] = expect(() => {
+    return spawnSync(rExecutable.getAbsolutePath(), ['--vanilla', '-s'], {
+      encoding: 'utf-8',
+      input: rQueryScript(),
+      env: rQueryEnvironment(),
+    });
+  });
+  if (spawnError) {
+    logger().logDebug(`Error querying information about R: ${spawnError}`);
+    return err(spawnError);
+  }
+
+  return rememberREnvironment(
+    rPath,
+    parseRQueryResult(rPath, {
+      stdout: spawned.stdout,
+      stderr: spawned.stderr,
+      status: spawned.status,
+      error: spawned.error,
+    }),
+  );
+}
+
+/**
+ * The asynchronous twin of detectREnvironment(); same query, same cache.
+ */
+export async function detectREnvironmentAsync(rPath: string): Promise<Expected<REnvironment>> {
+  const cached = rEnvironmentCache.get(rPath);
+  if (cached) {
+    return ok(cached);
+  }
+
+  const rExecutable = rExecutableFor(rPath);
+  logger().logDebug(`Querying information about R executable at path: ${rExecutable} (in background)`);
+
+  const result = await new Promise<RQueryResult>((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    const child = spawn(rExecutable.getAbsolutePath(), ['--vanilla', '-s'], {
+      env: rQueryEnvironment(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    child.stdout.on('data', (data) => (stdout += data));
+    child.stderr.on('data', (data) => (stderr += data));
+    child.on('error', (error) => resolve({ stdout, stderr, status: null, error }));
+    child.on('close', (code) => resolve({ stdout, stderr, status: code }));
+
+    // R may exit before reading its input; that is reported through 'close'
+    child.stdin.on('error', () => undefined);
+    child.stdin.end(rQueryScript());
+  });
+
+  return rememberREnvironment(rPath, parseRQueryResult(rPath, result));
+}
+
+function rememberREnvironment(rPath: string, result: Expected<REnvironment>): Expected<REnvironment> {
   const [environment, error] = result;
   if (!error) {
     rEnvironmentCache.set(rPath, environment);
@@ -231,17 +334,20 @@ export function detectREnvironment(rPath: string): Expected<REnvironment> {
   return result;
 }
 
-function detectREnvironmentImpl(rPath: string): Expected<REnvironment> {
+function rExecutableFor(rPath: string): FilePath {
   // resolve path to binary if we were given a directory
-  let rExecutable = new FilePath(rPath);
+  const rExecutable = new FilePath(rPath);
   if (rExecutable.isDirectory()) {
-    rExecutable = rExecutable.completeChildPath(process.platform === 'win32' ? kWindowsRExe : 'R');
+    return rExecutable.completeChildPath(process.platform === 'win32' ? kWindowsRExe : 'R');
   }
+  return rExecutable;
+}
 
-  // generate small script for querying information about R
-  // we write the marker character '\x1E' just in case the R installation
-  // prints some output on startup, so we can find and trim that out
-  const rQueryScript = String.raw`
+// small script for querying information about R; the marker character
+// '\x1E' lets us find our output even when the R installation prints
+// something on startup
+function rQueryScript(): string {
+  return String.raw`
 cat("\x1E", sep = "")
 writeLines(sep = "\x1F", c(
   format(getRversion()),
@@ -254,9 +360,9 @@ writeLines(sep = "\x1F", c(
   Sys.getenv("${kLdLibraryPathVariable}"),
   Sys.getenv("R_PLATFORM")
 ))`;
+}
 
-  logger().logDebug(`Querying information about R executable at path: ${rExecutable}`);
-
+function rQueryEnvironment(): NodeJS.ProcessEnv {
   // remove R-related environment variables before invoking R
   // note that we intentionally preserve an already-set LD_LIBRARY_PATH
   // see https://github.com/rstudio/rstudio/issues/15044 for motivation
@@ -268,26 +374,28 @@ writeLines(sep = "\x1F", c(
   delete envCopy['R_RUNTIME'];
   delete envCopy['R_SHARE_DIR'];
   delete envCopy['R_PLATFORM'];
+  return envCopy;
+}
 
-  const [result, error] = expect(() => {
-    return spawnSync(rExecutable.getAbsolutePath(), ['--vanilla', '-s'], {
-      encoding: 'utf-8',
-      input: rQueryScript,
-      env: envCopy,
-    });
-  });
+/** What running the query script produced. */
+export interface RQueryResult {
+  stdout: string | null;
+  stderr: string | null;
+  status: number | null;
+  error?: Error;
+}
 
+/**
+ * Turns the output of the R query script into the environment needed to
+ * launch a session with that R.
+ */
+export function parseRQueryResult(rPath: string, result: RQueryResult): Expected<REnvironment> {
   let stdout = result.stdout || '';
   logger().logDebug(`stdout: ${stdout.replaceAll('\x1E', EOL).replaceAll('\x1F', ';') || '[no stdout produced]'}`);
   logger().logDebug(`stderr: ${result.stderr || '[no stderr produced]'}`);
   logger().logDebug(`status: ${result.status} [${result.status === 0 ? 'success' : 'failure'}]`);
   if (result.error) {
     logger().logDebug(`error:  ${result.error}`);
-  }
-
-  if (error) {
-    logger().logDebug(`Error querying information about R: ${error}`);
-    return err(error);
   }
 
   // NOTE: It's possible for spawnSync to fail to launch a process,
@@ -374,7 +482,7 @@ export function scanForR(): Expected<string> {
   }
 }
 
-function scanForRPosix(): Expected<string> {
+function defaultRLocationsPosix(): string[] {
   const defaultLocations = ['/usr/bin/R', '/usr/local/bin/R', '/opt/local/bin/R'];
 
   if (process.platform == 'darwin') {
@@ -382,17 +490,31 @@ function scanForRPosix(): Expected<string> {
     // also check framework directory and then homebrew ARM locations for macOS
     defaultLocations.push('/Library/Frameworks/R.framework/Resources/bin/R');
     defaultLocations.push('/opt/homebrew/bin/R');
-  } else {
-    // for linux, look for R on the PATH
-    // should we launch the default shell to pick up the user modifications to the path?
-    const [rLocation, error] = executeCommand('/usr/bin/which R');
-    if (!error && rLocation) {
+  }
+
+  return defaultLocations;
+}
+
+// for linux, look for R on the PATH
+// should we launch the default shell to pick up the user modifications to the path?
+function rOnPathLinux(): string | null {
+  const [rLocation, error] = executeCommand('/usr/bin/which R');
+  if (!error && rLocation) {
+    return rLocation;
+  }
+  return null;
+}
+
+function scanForRPosix(): Expected<string> {
+  if (process.platform !== 'darwin') {
+    const rLocation = rOnPathLinux();
+    if (rLocation) {
       logger().logDebug(`Using ${rLocation} (found by /usr/bin/which/R)`);
       return ok(rLocation);
     }
   }
 
-  for (const location of defaultLocations) {
+  for (const location of defaultRLocationsPosix()) {
     if (isValidBinary(location)) {
       logger().logDebug(`Using ${location} (found by searching known locations)`);
       return ok(location);
@@ -400,6 +522,68 @@ function scanForRPosix(): Expected<string> {
   }
   // nothing found
   return err();
+}
+
+// --- early detection --------------------------------------------------------
+
+let rDetection: Promise<void> | undefined;
+
+/**
+ * The R executables startup would consider, in order, without asking the
+ * user: RSTUDIO_WHICH_R, then the platform's stored or well-known locations.
+ */
+function rCandidates(): string[] {
+  const rstudioWhichR = getenv('RSTUDIO_WHICH_R');
+  if (rstudioWhichR) {
+    return [rstudioWhichR];
+  }
+
+  if (process.platform === 'win32') {
+    return [...storedRCandidatesWin32().map((candidate) => candidate.path), ...registryRCandidatesWin32()];
+  }
+
+  const candidates = defaultRLocationsPosix();
+  if (process.platform !== 'darwin') {
+    const rLocation = rOnPathLinux();
+    if (rLocation) {
+      candidates.unshift(rLocation);
+    }
+  }
+  return candidates;
+}
+
+async function detectFirstValidR(): Promise<void> {
+  for (const candidate of rCandidates()) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+    const [, error] = await detectREnvironmentAsync(candidate);
+    if (!error) {
+      return;
+    }
+  }
+}
+
+/**
+ * Starts querying the R that startup is going to pick, so the answer is in
+ * the cache by the time the launch sequence asks for it. Call as early as
+ * possible; Electron's own startup is long enough to hide the query.
+ */
+export function startRDetection(): void {
+  if (rDetection !== undefined) {
+    return;
+  }
+  rDetection = detectFirstValidR().catch((error: unknown) => logger().logError(error));
+}
+
+/**
+ * Resolves once the early query (if one was started) has finished, so that
+ * the synchronous detection path finds its result in the cache.
+ */
+export async function rDetectionReady(): Promise<void> {
+  if (rDetection !== undefined) {
+    await rDetection;
+  }
 }
 
 export function findRInstallationsWin32(): string[] {
@@ -480,25 +664,11 @@ function scanForRWin32(): Expected<string> {
     return ok(rstudioWhichR);
   }
 
-  // look for a 64-bit version of R
-  if (process.arch === 'x64') {
-    const x64InstallPath = findDefaultInstallPathWin32('R64');
-    if (x64InstallPath) {
-      const x64BinaryPath = `${x64InstallPath}/bin/x64/${kWindowsRExe}`;
-      if (isValidBinary(x64BinaryPath)) {
-        logger().logDebug(`Using R ${x64BinaryPath} (found via registry)`);
-        return ok(x64BinaryPath);
-      }
-    }
-  }
-
-  // look for a 32-bit version of R
-  const i386InstallPath = findDefaultInstallPathWin32('R');
-  if (i386InstallPath) {
-    const i386BinaryPath = `${i386InstallPath}/bin/i386/${kWindowsRExe}`;
-    if (isValidBinary(i386BinaryPath)) {
-      logger().logDebug(`Using R ${i386BinaryPath} (found via registry)`);
-      return ok(i386BinaryPath);
+  // look for the default 64-bit, then 32-bit, version of R
+  for (const binaryPath of registryRCandidatesWin32()) {
+    if (isValidBinary(binaryPath)) {
+      logger().logDebug(`Using R ${binaryPath} (found via registry)`);
+      return ok(binaryPath);
     }
   }
 

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -80,7 +80,10 @@ export function rChooserLikely(): boolean {
   if (getenv('RSTUDIO_WHICH_R').length !== 0) {
     return false;
   }
-  return storedRCandidatesWin32().length === 0;
+
+  // a stored candidate that no longer exists on disk will fail validation
+  // and land in the chooser anyway
+  return !storedRCandidatesWin32().some((candidate) => existsSync(candidate.path));
 }
 
 export async function promptUserForR(platform = process.platform): Promise<Expected<string | null>> {

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -82,7 +82,11 @@ export function rChooserLikely(): boolean {
   }
 
   // a stored candidate that no longer exists on disk will fail validation
-  // and land in the chooser anyway
+  // and land in the chooser anyway. NOTE: full parity with promptUserForR's
+  // acceptance (isValidBinary) is deliberately not attempted: it launches R
+  // synchronously, which is the very cost the background probe exists to
+  // hide, and a stored R that exists but fails pays a single R attempt
+  // either way (the probe tries it first; validation then reads the cache)
   return !storedRCandidatesWin32().some((candidate) => existsSync(candidate.path));
 }
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -62,6 +62,7 @@ import { safeError } from '../core/err';
 import { userHomePathString } from '../core/user';
 import { buildInfo } from './build-info';
 import { showPersistentSplashScreen } from './splash-screen';
+import { harvestRendererTiming, startupCheckpoint } from './startup-timing';
 import { showWhatsNewWindow } from './whats-new-window';
 import { toReleaseSlug, isValidSlug, resolveReleaseName, resolveWhatsNewContentPath } from './whats-new-utils';
 
@@ -442,6 +443,8 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_on_workbench_initialized', (event, scratchPath: string) => {
+      startupCheckpoint('workbench-initialized');
+      harvestRendererTiming(event.sender);
       this.initialized = true;
       this.emit(GwtCallback.WORKBENCH_INITIALIZED);
       appState().setScratchTempDir(new FilePath(scratchPath));

--- a/src/node/desktop/src/main/login-shell-path.ts
+++ b/src/node/desktop/src/main/login-shell-path.ts
@@ -1,0 +1,179 @@
+/*
+ * login-shell-path.ts
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { spawn } from 'child_process';
+import ElectronStore from 'electron-store';
+import { getenv } from '../core/environment';
+import { logger } from '../core/logger';
+
+// On macOS an app launched from the Finder or Dock inherits launchd's minimal
+// PATH, so rsession asks the user's login shell for the real one at startup
+// (modules::path::initializePath in SessionPath.cpp). Depending on the
+// profile that takes anywhere from tens of milliseconds to over a second,
+// all of it on the session's critical path, on every launch.
+//
+// The desktop asks the shell instead, as early as it can, and hands the
+// answer to rsession through its environment (marked so the session skips
+// its own query). Which answer depends on how quickly the shell replies:
+//
+//   - if it has replied by the time the session is launched, its answer;
+//   - otherwise the previous launch's answer, remembered in the state store,
+//     with the fresh reply kept for next time (a changed profile therefore
+//     applies from the following launch on machines with a slow profile);
+//   - on a first launch with nothing remembered, the launch waits.
+
+/** Marker telling rsession that PATH already came from a login shell. */
+export const kSessionPathInitializedEnvVar = 'RSTUDIO_SESSION_PATH_INITIALIZED';
+
+// a profile that hangs must not hold up a first launch indefinitely
+const kQueryTimeoutMs = 10000;
+
+interface RememberedLoginShellPath {
+  shell: string;
+  path: string;
+}
+
+// Workaround for electron-store CommonJS/ESM type mismatch
+interface StoreInterface {
+  get(key: string, defaultValue?: unknown): unknown;
+  set(key: string, value: unknown): void;
+}
+
+let store: StoreInterface | undefined;
+let pending: Promise<string | null> | undefined;
+
+// the previous launch's answer, if any
+let remembered: string | null = null;
+
+// this launch's answer: undefined until the shell replies, null if it failed
+let fresh: string | null | undefined;
+
+function openStore(cwd?: string): StoreInterface {
+  const options: Record<string, unknown> = { name: 'startup-state' };
+  if (cwd) {
+    options.cwd = cwd;
+  }
+  return new ElectronStore(options) as unknown as StoreInterface;
+}
+
+function readRememberedPath(shell: string): string | null {
+  const entry = store?.get('loginShellPath') as RememberedLoginShellPath | undefined;
+  if (entry && entry.shell === shell && entry.path.length > 0) {
+    return entry.path;
+  }
+  return null;
+}
+
+async function queryLoginShellPath(shell: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    // don't inherit PATH, so the shell computes it from scratch
+    const env = { ...process.env };
+    delete env.PATH;
+
+    let stdout = '';
+    const child = spawn(shell, ['-l', '-c', 'printf "%s" "$PATH"'], { env, stdio: ['ignore', 'pipe', 'ignore'] });
+    const timer = setTimeout(() => {
+      logger().logWarning(`Login shell ${shell} did not report PATH within ${kQueryTimeoutMs}ms; killing it`);
+      child.kill();
+    }, kQueryTimeoutMs);
+
+    child.stdout.on('data', (data) => (stdout += data));
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      logger().logError(error);
+      resolve(null);
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        logger().logDebug(`Login shell ${shell} exited with code ${code}; not using its PATH`);
+        resolve(null);
+        return;
+      }
+
+      // profiles may print; the PATH is whatever came last
+      const lines = stdout.trim().split('\n');
+      const path = lines[lines.length - 1].trim();
+      resolve(path.length > 0 ? path : null);
+    });
+  });
+}
+
+/**
+ * Starts asking the login shell for PATH. Call as early as possible; does
+ * nothing except on macOS.
+ *
+ * @param storeCwd Directory for the state file (tests only; defaults to the
+ *   app's user data directory).
+ */
+export function startLoginShellPathQuery(storeCwd?: string): void {
+  if (pending !== undefined || process.platform !== 'darwin') {
+    return;
+  }
+
+  const shell = getenv('RSTUDIO_SESSION_SHELL') || getenv('SHELL');
+  if (shell.length === 0) {
+    return;
+  }
+
+  try {
+    store = openStore(storeCwd);
+    remembered = readRememberedPath(shell);
+  } catch (error: unknown) {
+    logger().logError(error);
+  }
+
+  pending = queryLoginShellPath(shell).then((path) => {
+    fresh = path;
+    if (path !== null && path !== remembered) {
+      logger().logDebug(`Login shell PATH: ${path}`);
+      try {
+        store?.set('loginShellPath', { shell, path } as RememberedLoginShellPath);
+      } catch (error: unknown) {
+        logger().logError(error);
+      }
+    }
+    return path;
+  });
+}
+
+/**
+ * The PATH to launch a session with, without waiting: the shell's answer if
+ * it has arrived, otherwise the previous launch's, otherwise null.
+ */
+export function cachedLoginShellPath(): string | null {
+  return fresh ?? remembered;
+}
+
+/**
+ * The PATH to launch a session with. Resolves immediately when the shell
+ * has answered or a previous launch's answer is available; on a first
+ * launch it waits for the shell (bounded by the query timeout).
+ */
+export async function loginShellPath(): Promise<string | null> {
+  const known = cachedLoginShellPath();
+  if (known !== null || pending === undefined) {
+    return known;
+  }
+  return pending;
+}
+
+/** Forgets everything; tests only. */
+export function resetLoginShellPath(): void {
+  store = undefined;
+  pending = undefined;
+  remembered = null;
+  fresh = undefined;
+}

--- a/src/node/desktop/src/main/login-shell-path.ts
+++ b/src/node/desktop/src/main/login-shell-path.ts
@@ -86,7 +86,11 @@ async function queryLoginShellPath(shell: string): Promise<string | null> {
     const child = spawn(shell, ['-l', '-c', 'printf "%s" "$PATH"'], { env, stdio: ['ignore', 'pipe', 'ignore'] });
     const timer = setTimeout(() => {
       logger().logWarning(`Login shell ${shell} did not report PATH within ${kQueryTimeoutMs}ms; killing it`);
-      child.kill();
+      // resolve now rather than waiting for 'close': a profile that traps or
+      // ignores the signal must not leave a first launch waiting (late
+      // 'close'/'error' resolutions are no-ops)
+      child.kill('SIGKILL');
+      resolve(null);
     }, kQueryTimeoutMs);
 
     child.stdout.on('data', (data) => (stdout += data));

--- a/src/node/desktop/src/main/login-shell-path.ts
+++ b/src/node/desktop/src/main/login-shell-path.ts
@@ -14,6 +14,8 @@
  */
 
 import { spawn } from 'child_process';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
 import ElectronStore from 'electron-store';
 import { getenv } from '../core/environment';
 import { logger } from '../core/logger';
@@ -173,19 +175,55 @@ export function loginShellPathFailed(): boolean {
   return fresh === null;
 }
 
-// standard tool locations a login shell would normally contribute; appended
-// as a fallback when the shell itself could not be asked
+// Homebrew's locations, which path_helper does not know about; appended as a
+// fallback when the shell itself could not be asked
 const kDefaultToolPaths = ['/usr/local/bin', '/opt/homebrew/bin'];
 
-/** The given PATH, extended with the standard tool locations it lacks. */
+/**
+ * The given PATH, extended with the standard tool locations it lacks: the
+ * path_helper sources (/etc/paths, /etc/paths.d/*) the session's own
+ * last-resort initialization would read, plus Homebrew's directories.
+ */
 export function withDefaultToolPaths(path: string): string {
   const parts = path.length > 0 ? path.split(':') : [];
-  for (const dir of kDefaultToolPaths) {
-    if (!parts.includes(dir)) {
-      parts.push(dir);
+
+  const append = (dir: string) => {
+    const trimmed = dir.trim();
+    if (trimmed.length > 0 && !parts.includes(trimmed)) {
+      parts.push(trimmed);
+    }
+  };
+
+  for (const file of etcPathsFiles()) {
+    try {
+      for (const line of readFileSync(file, 'utf8').split('\n')) {
+        append(line);
+      }
+    } catch (error: unknown) {
+      logger().logError(error);
     }
   }
+
+  for (const dir of kDefaultToolPaths) {
+    append(dir);
+  }
+
   return parts.join(':');
+}
+
+function etcPathsFiles(): string[] {
+  const files: string[] = [];
+  if (existsSync('/etc/paths')) {
+    files.push('/etc/paths');
+  }
+  try {
+    for (const entry of readdirSync('/etc/paths.d')) {
+      files.push(join('/etc/paths.d', entry));
+    }
+  } catch {
+    // no /etc/paths.d
+  }
+  return files;
 }
 
 /**

--- a/src/node/desktop/src/main/login-shell-path.ts
+++ b/src/node/desktop/src/main/login-shell-path.ts
@@ -180,12 +180,13 @@ export function loginShellPathFailed(): boolean {
 const kDefaultToolPaths = ['/usr/local/bin', '/opt/homebrew/bin'];
 
 /**
- * The given PATH, extended with the standard tool locations it lacks: the
- * path_helper sources (/etc/paths, /etc/paths.d/*) the session's own
- * last-resort initialization would read, plus Homebrew's directories.
+ * A fallback PATH built the way a login shell would: the path_helper sources
+ * (/etc/paths, /etc/paths.d/*) first -- the same inputs, in the same order,
+ * as the session's own last-resort initialization -- then Homebrew's
+ * directories, then whatever inherited entries are not already present.
  */
 export function withDefaultToolPaths(path: string): string {
-  const parts = path.length > 0 ? path.split(':') : [];
+  const parts: string[] = [];
 
   const append = (dir: string) => {
     const trimmed = dir.trim();
@@ -205,6 +206,10 @@ export function withDefaultToolPaths(path: string): string {
   }
 
   for (const dir of kDefaultToolPaths) {
+    append(dir);
+  }
+
+  for (const dir of path.split(':')) {
     append(dir);
   }
 

--- a/src/node/desktop/src/main/login-shell-path.ts
+++ b/src/node/desktop/src/main/login-shell-path.ts
@@ -164,6 +164,16 @@ export function cachedLoginShellPath(): string | null {
 }
 
 /**
+ * True when this launch's query finished without an answer (shell failure or
+ * timeout). The session should then not repeat the query: its own probe has
+ * no timeout, so it would hang on the same profile the desktop just gave up
+ * on.
+ */
+export function loginShellPathFailed(): boolean {
+  return fresh === null;
+}
+
+/**
  * The PATH to launch a session with. Resolves immediately when the shell
  * has answered or a previous launch's answer is available; on a first
  * launch it waits for the shell (bounded by the query timeout).

--- a/src/node/desktop/src/main/login-shell-path.ts
+++ b/src/node/desktop/src/main/login-shell-path.ts
@@ -95,7 +95,9 @@ async function queryLoginShellPath(shell: string): Promise<string | null> {
       logger().logError(error);
       resolve(null);
     });
-    child.on('exit', (code) => {
+    // 'close' rather than 'exit': stdout is only guaranteed drained once the
+    // stdio streams have closed, and a truncated PATH must not be cached
+    child.on('close', (code) => {
       clearTimeout(timer);
       if (code !== 0) {
         logger().logDebug(`Login shell ${shell} exited with code ${code}; not using its PATH`);

--- a/src/node/desktop/src/main/login-shell-path.ts
+++ b/src/node/desktop/src/main/login-shell-path.ts
@@ -173,6 +173,21 @@ export function loginShellPathFailed(): boolean {
   return fresh === null;
 }
 
+// standard tool locations a login shell would normally contribute; appended
+// as a fallback when the shell itself could not be asked
+const kDefaultToolPaths = ['/usr/local/bin', '/opt/homebrew/bin'];
+
+/** The given PATH, extended with the standard tool locations it lacks. */
+export function withDefaultToolPaths(path: string): string {
+  const parts = path.length > 0 ? path.split(':') : [];
+  for (const dir of kDefaultToolPaths) {
+    if (!parts.includes(dir)) {
+      parts.push(dir);
+    }
+  }
+  return parts.join(':');
+}
+
 /**
  * The PATH to launch a session with. Resolves immediately when the shell
  * has answered or a previous launch's answer is available; on a first

--- a/src/node/desktop/src/main/login-shell-path.ts
+++ b/src/node/desktop/src/main/login-shell-path.ts
@@ -39,6 +39,21 @@ import { logger } from '../core/logger';
 /** Marker telling rsession that PATH already came from a login shell. */
 export const kSessionPathInitializedEnvVar = 'RSTUDIO_SESSION_PATH_INITIALIZED';
 
+// the session's own heuristic (initializePath in SessionPath.cpp): launchd's
+// PATH never contains /usr/local/bin, so its presence means the app was
+// launched from a terminal and PATH was already set up by a shell
+const kShellDerivedPathPattern = /(^|:)\/usr\/local\/bin\/?(:|$)/;
+
+/**
+ * Whether a PATH was already set up by a shell, i.e. RStudio was launched
+ * from a terminal. Such a PATH must be kept as-is: it can carry
+ * customizations (an activated conda or Python environment, direnv) that a
+ * fresh login shell would not reproduce.
+ */
+export function isShellDerivedPath(path: string): boolean {
+  return kShellDerivedPathPattern.test(path);
+}
+
 // a profile that hangs must not hold up a first launch indefinitely
 const kQueryTimeoutMs = 10000;
 

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -254,6 +254,13 @@ export class MainWindow extends GwtWindow {
       });
   }
 
+  /**
+   * Shows the "Initializing R" placeholder page while the session starts.
+   */
+  async loadLoadingPage(): Promise<void> {
+    return this.loadUrl(LOADING_WINDOW_WEBPACK_ENTRY, false);
+  }
+
   async loadUrl(url: string, updateBaseUrl = true): Promise<void> {
     // pass along the shared secret with every request
     const filter = {

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -401,13 +401,14 @@ export class MainWindow extends GwtWindow {
           .then((error: Err) => {
             if (error) {
               logger().logError(error);
+            } else {
+              startupCheckpoint('session-url-reachable');
             }
           })
           .catch((error) => {
             logger().logError(error);
           })
           .finally(() => {
-            startupCheckpoint('session-url-reachable');
             this.reload();
           });
       } else {

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -31,6 +31,7 @@ import { MenuCallback } from './menu-callback';
 import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import { RCommandEvaluator } from './r-command-evaluator';
 import { SessionLauncher } from './session-launcher';
+import { startupCheckpoint } from './startup-timing';
 import { waitForUrlWithTimeout } from './url-utils';
 import { isAutomated, registerWebContentsDebugHandlers } from './utils';
 
@@ -387,6 +388,7 @@ export class MainWindow extends GwtWindow {
         // the load failed, but we haven't yet received word that the
         // session has failed to load. let the user know that the R
         // session is still initializing, and then reload the page.
+        startupCheckpoint('load-failed');
         this.loadUrl(LOADING_WINDOW_WEBPACK_ENTRY, false).catch((error: unknown) => logger().logError(error));
         waitForUrlWithTimeout(this.options.baseUrl ?? '', reloadWaitDuration, reloadWaitDuration, 10)
           .then((error: Err) => {
@@ -398,6 +400,7 @@ export class MainWindow extends GwtWindow {
             logger().logError(error);
           })
           .finally(() => {
+            startupCheckpoint('session-url-reachable');
             this.reload();
           });
       } else {

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -22,6 +22,7 @@ import { Application } from './application';
 import { initI18n } from './i18n-manager';
 import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import { parseStatus } from './program-status';
+import { recordProcessStart, startupCheckpoint } from './startup-timing';
 import { createStandaloneErrorDialog } from './utils';
 import { Xdg } from '../core/xdg';
 import { existsSync, readFileSync } from 'fs';
@@ -141,8 +142,10 @@ class RStudioMain {
     if (!parseStatus(await rstudio.beforeAppReady())) {
       return;
     }
+    startupCheckpoint('before-app-ready-done');
 
     await app.whenReady();
+    startupCheckpoint('app-ready');
 
     if (!parseStatus(await rstudio.run())) {
       return;
@@ -151,6 +154,8 @@ class RStudioMain {
 }
 
 // Startup
+recordProcessStart();
+startupCheckpoint('main-entry');
 initI18n();
 
 const main = new RStudioMain();

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -20,6 +20,7 @@ import { logLevel, logger } from '../core/logger';
 import { setApplication } from './app-state';
 import { Application } from './application';
 import { initI18n } from './i18n-manager';
+import { startLoginShellPathQuery } from './login-shell-path';
 import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import { parseStatus } from './program-status';
 import { recordProcessStart, startupCheckpoint } from './startup-timing';
@@ -156,6 +157,11 @@ class RStudioMain {
 // Startup
 recordProcessStart();
 startupCheckpoint('main-entry');
+
+// the login shell is slow to answer and the session will need its PATH, so
+// ask before anything else (see login-shell-path.ts)
+startLoginShellPathQuery();
+
 initI18n();
 
 const main = new RStudioMain();

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -19,6 +19,7 @@ import { safeError } from '../core/err';
 import { logLevel, logger } from '../core/logger';
 import { setApplication } from './app-state';
 import { Application } from './application';
+import { startRDetection } from './detect-r';
 import { initI18n } from './i18n-manager';
 import { startLoginShellPathQuery } from './login-shell-path';
 import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
@@ -159,8 +160,10 @@ recordProcessStart();
 startupCheckpoint('main-entry');
 
 // the login shell is slow to answer and the session will need its PATH, so
-// ask before anything else (see login-shell-path.ts)
+// ask before anything else (see login-shell-path.ts); likewise start asking
+// R about itself, which takes about as long as Electron's own startup
 startLoginShellPathQuery();
+startRDetection();
 
 initI18n();
 

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -43,7 +43,12 @@ import path from 'path';
 import { createSplashScreen } from './splash-screen';
 import { startupCheckpoint } from './startup-timing';
 import { readMachoArchitectures } from '../core/macho';
-import { cachedLoginShellPath, kSessionPathInitializedEnvVar, loginShellPath } from './login-shell-path';
+import {
+  cachedLoginShellPath,
+  kSessionPathInitializedEnvVar,
+  loginShellPath,
+  loginShellPathFailed,
+} from './login-shell-path';
 import { probeUrl } from './url-utils';
 import { showWhatsNewWindow } from './whats-new-window';
 import {
@@ -129,6 +134,11 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
     const shellPath = cachedLoginShellPath();
     if (shellPath) {
       env['PATH'] = shellPath;
+      env[kSessionPathInitializedEnvVar] = '1';
+    } else if (loginShellPathFailed()) {
+      // the desktop's bounded query failed or timed out; the session's own
+      // probe has no timeout and would hang on the same profile, so tell it
+      // to keep the inherited PATH instead
       env[kSessionPathInitializedEnvVar] = '1';
     }
   }

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -45,6 +45,7 @@ import { startupCheckpoint } from './startup-timing';
 import { readMachoArchitectures } from '../core/macho';
 import {
   cachedLoginShellPath,
+  isShellDerivedPath,
   kSessionPathInitializedEnvVar,
   loginShellPath,
   loginShellPathFailed,
@@ -130,19 +131,28 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
       absPath = new FilePath('/usr/bin/arch');
     }
 
-    // adopt the login shell's PATH if we have it, and say so, so rsession
-    // need not spend its own startup asking the shell (see login-shell-path.ts)
-    const shellPath = cachedLoginShellPath();
-    if (shellPath) {
-      env['PATH'] = shellPath;
+    // settle the PATH the session starts with (see login-shell-path.ts).
+    // a terminal launch already carries a shell's PATH -- keep it, along
+    // with any customizations (an activated conda environment, direnv) a
+    // fresh login shell would lose, exactly as the session's own
+    // initializePath() always has
+    if (isShellDerivedPath(env['PATH'] ?? '')) {
       env[kSessionPathInitializedEnvVar] = '1';
-    } else if (loginShellPathFailed()) {
-      // the desktop's bounded query failed or timed out; the session's own
-      // probe has no timeout and would hang on the same profile, so tell it
-      // to keep the inherited PATH, extended with the standard tool
-      // locations a login shell would normally contribute
-      env['PATH'] = withDefaultToolPaths(env['PATH'] ?? '');
-      env[kSessionPathInitializedEnvVar] = '1';
+    } else {
+      // adopt the login shell's PATH if we have it, and say so, so rsession
+      // need not spend its own startup asking the shell
+      const shellPath = cachedLoginShellPath();
+      if (shellPath) {
+        env['PATH'] = shellPath;
+        env[kSessionPathInitializedEnvVar] = '1';
+      } else if (loginShellPathFailed()) {
+        // the desktop's bounded query failed or timed out; the session's own
+        // probe has no timeout and would hang on the same profile, so tell it
+        // to keep the inherited PATH, extended with the standard tool
+        // locations a login shell would normally contribute
+        env['PATH'] = withDefaultToolPaths(env['PATH'] ?? '');
+        env[kSessionPathInitializedEnvVar] = '1';
+      }
     }
   }
 
@@ -164,18 +174,14 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
 
 /**
  * Architectures of R's shared library, as `/usr/bin/file` would report them
- * but without launching a process. Unreadable files yield an empty list,
- * which callers treat as "not the architecture we were looking for".
+ * but without launching a process. A file that is not a Mach-O image yields
+ * an empty list; a file that cannot be read throws, failing the launch --
+ * the callers would otherwise each guess a (different) architecture.
  */
 function libRArchitectures(rLib: FilePath): string[] {
-  try {
-    const architectures = readMachoArchitectures(rLib.getAbsolutePath());
-    logger().logDebug(`${rLib.getAbsolutePath()}: ${architectures.join(', ') || 'not a Mach-O image'}`);
-    return architectures;
-  } catch (error: unknown) {
-    logger().logError(error);
-    return [];
-  }
+  const architectures = readMachoArchitectures(rLib.getAbsolutePath());
+  logger().logDebug(`${rLib.getAbsolutePath()}: ${architectures.join(', ') || 'not a Mach-O image'}`);
+  return architectures;
 }
 
 function abendLogPath(): FilePath {
@@ -269,9 +275,12 @@ export class SessionLauncher {
     logger().logDiagnosticEnvVar('R_USER');
     logger().logDiagnosticEnvVar('RSTUDIO_CPP_BUILD_OUTPUT');
 
-    // settle which PATH the session gets; this only waits on a first launch
+    // settle which PATH the session gets; this only waits on a first launch,
+    // and never on a terminal launch, whose PATH is kept as-is
     // (see login-shell-path.ts)
-    await loginShellPath();
+    if (!isShellDerivedPath(getenv('PATH'))) {
+      await loginShellPath();
+    }
     startupCheckpoint('login-shell-path-ready');
 
     // launch the process

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -391,7 +391,10 @@ export class SessionLauncher {
     startupCheckpoint('session-probe-begin');
     const deadline = Date.now() + kProbeTimeoutMs;
     while (Date.now() < deadline) {
-      if (this.sessionProcess?.exitCode !== null) {
+      // exitCode stays null when the process dies from a signal, so check
+      // signalCode as well
+      const session = this.sessionProcess;
+      if (session == null || session.exitCode !== null || session.signalCode !== null) {
         return false;
       }
       if (await probeUrl(url)) {

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -41,6 +41,7 @@ import { waitForUrlWithTimeout } from './url-utils';
 import { createStandaloneErrorDialog, findRepoRoot, getCurrentlyUniqueFolderName, isAutomated, userLogPath } from './utils';
 import path from 'path';
 import { createSplashScreen } from './splash-screen';
+import { startupCheckpoint } from './startup-timing';
 import { showWhatsNewWindow } from './whats-new-window';
 import {
   toReleaseSlug,
@@ -234,6 +235,7 @@ export class SessionLauncher {
     } catch (err: unknown) {
       return safeError(err);
     }
+    startupCheckpoint('session-spawned');
 
     logger().logDiagnostic(`\nR session launched, attempting to connect on port ${launchContext.port}...`);
 
@@ -244,6 +246,7 @@ export class SessionLauncher {
     this.appLaunch.setActivationWindow(this.mainWindow);
 
     ElectronDesktopOptions().restoreMainWindowBounds(this.mainWindow.window);
+    startupCheckpoint('window-created');
 
     logger().logDiagnostic('\nConnected to R session, attempting to initialize...\n');
 
@@ -270,6 +273,7 @@ export class SessionLauncher {
       // may not be reliable, especially if the user switches focus between different
       // windows/apps while starting up.
       this.mainWindow.window.webContents.once('did-finish-load', async () => {
+        startupCheckpoint('did-finish-load');
         if (appState().startupDelayMs > 0) {
           await setTimeoutPromise(appState().startupDelayMs);
         }
@@ -281,6 +285,7 @@ export class SessionLauncher {
         } else {
           this.mainWindow?.window.show();
         }
+        startupCheckpoint('window-shown');
 
         // if the splash screen displayed, keep it visible for another brief period to
         // reduce cases where it flashes and hides without being readable
@@ -320,6 +325,7 @@ export class SessionLauncher {
       });
       appState().activation().setMainWindow(this.mainWindow.window);
       this.appLaunch.activateWindow();
+      startupCheckpoint('load-url');
       this.mainWindow.loadUrl(launchContext.url).catch((reason) => {
         logger().logErrorMessage(`Failed to load ${launchContext.url}: ${reason}`);
       });
@@ -609,6 +615,7 @@ export class SessionLauncher {
             } else {
               this.splash.show();
             }
+            startupCheckpoint('splash-shown');
           }
         })
         .catch((err) => logger().logError(err));

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { ChildProcess, execSync, spawn } from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 import { app, BrowserWindow } from 'electron';
 import fs, { rmSync } from 'fs';
 
@@ -42,6 +42,9 @@ import { createStandaloneErrorDialog, findRepoRoot, getCurrentlyUniqueFolderName
 import path from 'path';
 import { createSplashScreen } from './splash-screen';
 import { startupCheckpoint } from './startup-timing';
+import { readMachoArchitectures } from '../core/macho';
+import { cachedLoginShellPath, kSessionPathInitializedEnvVar, loginShellPath } from './login-shell-path';
+import { probeUrl } from './url-utils';
 import { showWhatsNewWindow } from './whats-new-window';
 import {
   toReleaseSlug,
@@ -108,8 +111,8 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
     // x86 or arm64 versions of the libraries in the launched rsession
     const path = absPath.getAbsolutePath();
     if (process.arch === 'arm64') {
-      const fileInfo = execSync(`/usr/bin/file "${rLib}"`, { encoding: 'utf-8' });
-      if (fileInfo.indexOf('arm64') === -1 && fileInfo.indexOf('x86_64') !== -1) {
+      const architectures = libRArchitectures(rLib);
+      if (!architectures.includes('arm64') && architectures.includes('x86_64')) {
         argList = ['-x86_64', ...dyldArgs, path, ...argList];
         absPath = new FilePath('/usr/bin/arch');
       } else {
@@ -119,6 +122,14 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
     } else {
       argList = ['-x86_64', ...dyldArgs, path, ...argList];
       absPath = new FilePath('/usr/bin/arch');
+    }
+
+    // adopt the login shell's PATH if we have it, and say so, so rsession
+    // need not spend its own startup asking the shell (see login-shell-path.ts)
+    const shellPath = cachedLoginShellPath();
+    if (shellPath) {
+      env['PATH'] = shellPath;
+      env[kSessionPathInitializedEnvVar] = '1';
     }
   }
 
@@ -135,6 +146,22 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
   } else {
     // for diagnostics, redirect child process stdio to this process
     return spawn(absPath.getAbsolutePath(), argList, { stdio: 'inherit', env: env });
+  }
+}
+
+/**
+ * Architectures of R's shared library, as `/usr/bin/file` would report them
+ * but without launching a process. Unreadable files yield an empty list,
+ * which callers treat as "not the architecture we were looking for".
+ */
+function libRArchitectures(rLib: FilePath): string[] {
+  try {
+    const architectures = readMachoArchitectures(rLib.getAbsolutePath());
+    logger().logDebug(`${rLib.getAbsolutePath()}: ${architectures.join(', ') || 'not a Mach-O image'}`);
+    return architectures;
+  } catch (error: unknown) {
+    logger().logError(error);
+    return [];
   }
 }
 
@@ -228,6 +255,11 @@ export class SessionLauncher {
     logger().logDiagnosticEnvVar('HOME');
     logger().logDiagnosticEnvVar('R_USER');
     logger().logDiagnosticEnvVar('RSTUDIO_CPP_BUILD_OUTPUT');
+
+    // settle which PATH the session gets; this only waits on a first launch
+    // (see login-shell-path.ts)
+    await loginShellPath();
+    startupCheckpoint('login-shell-path-ready');
 
     // launch the process
     try {
@@ -325,6 +357,19 @@ export class SessionLauncher {
       });
       appState().activation().setMainWindow(this.mainWindow.window);
       this.appLaunch.activateWindow();
+
+      // Show the placeholder page right away and navigate to the session only
+      // once it is listening. Navigating immediately would fail (the session
+      // needs a moment to open its port) and cost a reload cycle with a
+      // coarse retry interval on top; see MainWindow.onLoadFinished.
+      this.mainWindow.loadLoadingPage().catch((error: unknown) => logger().logError(error));
+      const listening = await this.waitForSessionListener(launchContext.url);
+      if (!listening) {
+        // the session exited before listening; onRSessionExited has shown
+        // (or will show) the launch error page
+        return success();
+      }
+
       startupCheckpoint('load-url');
       this.mainWindow.loadUrl(launchContext.url).catch((reason) => {
         logger().logErrorMessage(`Failed to load ${launchContext.url}: ${reason}`);
@@ -332,6 +377,31 @@ export class SessionLauncher {
     }
 
     return success();
+  }
+
+  /**
+   * Polls until the session's HTTP listener answers. Resolves false if the
+   * session process exits first; after the timeout, resolves true anyway so
+   * the normal load-failure handling can take over.
+   */
+  private async waitForSessionListener(url: string): Promise<boolean> {
+    const kProbeIntervalMs = 20;
+    const kProbeTimeoutMs = 30000;
+
+    const deadline = Date.now() + kProbeTimeoutMs;
+    while (Date.now() < deadline) {
+      if (this.sessionProcess?.exitCode !== null) {
+        return false;
+      }
+      if (await probeUrl(url)) {
+        startupCheckpoint('session-listening');
+        return true;
+      }
+      await setTimeoutPromise(kProbeIntervalMs);
+    }
+
+    logger().logWarning(`Session did not start listening on ${url} within ${kProbeTimeoutMs}ms`);
+    return true;
   }
 
   closeAllSatellites(): void {
@@ -675,11 +745,8 @@ export class SessionLauncher {
     // with the arm64 session binary (rsession-arm64) or with the x64 session binary (rsession)
     if (app.isPackaged && process.platform === 'darwin' && process.arch === 'arm64') {
       const rHome = getenv('R_HOME');
-      const rLibPath = `${rHome}/lib/libR.dylib`;
-      logger().logDebug(`$ /usr/bin/file "${rLibPath}"`);
-      const fileInfo = execSync(`/usr/bin/file "${rLibPath}"`, { encoding: 'utf-8' });
-      logger().logDebug(fileInfo);
-      if (fileInfo.indexOf('arm64') !== -1) {
+      const rLib = new FilePath(rHome).completePath('lib/libR.dylib');
+      if (libRArchitectures(rLib).includes('arm64')) {
         this.sessionPath = this.sessionPath.getParent().completeChildPath('rsession-arm64');
         logger().logDebug(`R is arm64; using ${this.sessionPath}`);
       } else {

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -388,6 +388,7 @@ export class SessionLauncher {
     const kProbeIntervalMs = 20;
     const kProbeTimeoutMs = 30000;
 
+    startupCheckpoint('session-probe-begin');
     const deadline = Date.now() + kProbeTimeoutMs;
     while (Date.now() < deadline) {
       if (this.sessionProcess?.exitCode !== null) {

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -48,6 +48,7 @@ import {
   kSessionPathInitializedEnvVar,
   loginShellPath,
   loginShellPathFailed,
+  withDefaultToolPaths,
 } from './login-shell-path';
 import { probeUrl } from './url-utils';
 import { showWhatsNewWindow } from './whats-new-window';
@@ -138,7 +139,9 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
     } else if (loginShellPathFailed()) {
       // the desktop's bounded query failed or timed out; the session's own
       // probe has no timeout and would hang on the same profile, so tell it
-      // to keep the inherited PATH instead
+      // to keep the inherited PATH, extended with the standard tool
+      // locations a login shell would normally contribute
+      env['PATH'] = withDefaultToolPaths(env['PATH'] ?? '');
       env[kSessionPathInitializedEnvVar] = '1';
     }
   }

--- a/src/node/desktop/src/main/startup-timing.ts
+++ b/src/node/desktop/src/main/startup-timing.ts
@@ -130,8 +130,12 @@ export function harvestRendererTiming(webContents: WebContents): void {
     webContents
       .executeJavaScript(kProbeScript)
       .then((completed: boolean) => {
-        if (completed || Date.now() >= deadline) {
-          setTimeout(() => harvestNow(webContents), kHarvestSettleMs);
+        if (completed) {
+          setTimeout(() => harvestNow(webContents, true), kHarvestSettleMs);
+        } else if (Date.now() >= deadline) {
+          // harvest what exists, but mark the timeline as incomplete so
+          // consumers do not mistake a stalled startup for a finished one
+          setTimeout(() => harvestNow(webContents, false), kHarvestSettleMs);
         } else {
           setTimeout(poll, kHarvestPollIntervalMs);
         }
@@ -141,7 +145,7 @@ export function harvestRendererTiming(webContents: WebContents): void {
   setTimeout(poll, kHarvestPollIntervalMs);
 }
 
-function harvestNow(webContents: WebContents): void {
+function harvestNow(webContents: WebContents, completed: boolean): void {
   // performance.timeOrigin is epoch-based, so everything can be converted to
   // the same wall-clock scale used by the other tiers
   const script = String.raw`
@@ -174,7 +178,8 @@ function harvestNow(webContents: WebContents): void {
       for (const entry of entries) {
         write({ tier: 'client', name: entry.name, t: entry.t, dur: entry.dur });
       }
-      write({ tier: 'desktop', name: 'timing-harvested', t: nowMs(), pid: process.pid });
+      const name = completed ? 'timing-harvested' : 'timing-harvest-timeout';
+      write({ tier: 'desktop', name, t: nowMs(), pid: process.pid });
     })
     .catch((error: unknown) => logger().logError(error));
 }

--- a/src/node/desktop/src/main/startup-timing.ts
+++ b/src/node/desktop/src/main/startup-timing.ts
@@ -1,0 +1,151 @@
+/*
+ * startup-timing.ts
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { WebContents } from 'electron';
+import { appendFileSync } from 'fs';
+import { performance } from 'perf_hooks';
+import { getenv } from '../core/environment';
+import { logger } from '../core/logger';
+
+// Startup checkpoints are recorded only when RSTUDIO_STARTUP_TIMING names a
+// file. Each checkpoint is one JSON line:
+//
+//    {"tier":"desktop","name":"<name>","t":<epoch ms>,"pid":<pid>}
+//
+// with an optional "dur" (ms) for completed spans. The rsession process
+// inherits the variable and appends its own "session" checkpoints, and the
+// renderer's performance timeline is harvested into "client" checkpoints
+// once the workbench is up, so the file holds a single cross-process
+// timeline. See tasks/startup-timing.ts for the report.
+
+interface Checkpoint {
+  tier: 'desktop' | 'client';
+  name: string;
+  t: number;
+  pid?: number;
+  dur?: number;
+}
+
+// how long to wait after the workbench initializes before harvesting the
+// renderer timeline; long enough to include the deferred-init tail
+const kRendererHarvestDelayMs = 3000;
+
+// looked up on every checkpoint rather than cached: there are only a handful
+// of checkpoints, and this keeps the module trivially testable
+function resolveTimingFile(): string | null {
+  const value = getenv('RSTUDIO_STARTUP_TIMING');
+  return value.length > 0 ? value : null;
+}
+
+function nowMs(): number {
+  return performance.timeOrigin + performance.now();
+}
+
+function write(checkpoint: Checkpoint): void {
+  const file = resolveTimingFile();
+  if (!file) {
+    return;
+  }
+
+  try {
+    appendFileSync(file, JSON.stringify(checkpoint) + '\n');
+  } catch (error: unknown) {
+    logger().logError(error);
+  }
+}
+
+export function startupTimingEnabled(): boolean {
+  return resolveTimingFile() !== null;
+}
+
+/**
+ * Records a named desktop startup checkpoint at the current time.
+ */
+export function startupCheckpoint(name: string): void {
+  if (!startupTimingEnabled()) {
+    return;
+  }
+  write({ tier: 'desktop', name: name, t: nowMs(), pid: process.pid });
+}
+
+/**
+ * Records the Electron process creation time, which precedes any JavaScript
+ * we run; the gap to the first checkpoint is the runtime's own boot cost.
+ */
+export function recordProcessStart(): void {
+  if (!startupTimingEnabled()) {
+    return;
+  }
+
+  const created = process.getCreationTime();
+  if (created !== null) {
+    write({ tier: 'desktop', name: 'process-start', t: created, pid: process.pid });
+  }
+}
+
+interface RendererEntry {
+  name: string;
+  t: number;
+  dur?: number;
+}
+
+/**
+ * Copies the renderer's navigation timing, resource timing and
+ * `performance.mark()` entries into the timing file as "client" checkpoints.
+ * The GWT client records marks prefixed "rstudio:" at its own milestones.
+ */
+export function harvestRendererTiming(webContents: WebContents): void {
+  if (!startupTimingEnabled()) {
+    return;
+  }
+
+  // performance.timeOrigin is epoch-based, so everything can be converted to
+  // the same wall-clock scale used by the other tiers
+  const script = String.raw`
+    (function() {
+      var origin = performance.timeOrigin;
+      var entries = [];
+      var nav = performance.getEntriesByType('navigation')[0];
+      if (nav) {
+        entries.push({ name: 'navigation-start', t: origin + nav.startTime });
+        entries.push({ name: 'response-start', t: origin + nav.responseStart });
+        entries.push({ name: 'dom-interactive', t: origin + nav.domInteractive });
+        entries.push({ name: 'dom-content-loaded', t: origin + nav.domContentLoadedEventEnd });
+        entries.push({ name: 'load', t: origin + nav.loadEventEnd });
+      }
+      performance.getEntriesByType('resource').forEach(function(e) {
+        var name = e.name.replace(/^https?:\/\/[^\/]+/, '');
+        entries.push({ name: 'resource:' + name, t: origin + e.startTime, dur: e.duration });
+      });
+      performance.getEntriesByType('mark').forEach(function(e) {
+        if (e.name.indexOf('rstudio:') === 0) {
+          entries.push({ name: e.name.substring('rstudio:'.length), t: origin + e.startTime });
+        }
+      });
+      return entries;
+    })()`;
+
+  setTimeout(() => {
+    webContents
+      .executeJavaScript(script)
+      .then((entries: RendererEntry[]) => {
+        for (const entry of entries) {
+          write({ tier: 'client', name: entry.name, t: entry.t, dur: entry.dur });
+        }
+        write({ tier: 'desktop', name: 'timing-harvested', t: nowMs(), pid: process.pid });
+      })
+      .catch((error: unknown) => logger().logError(error));
+  }, kRendererHarvestDelayMs);
+}

--- a/src/node/desktop/src/main/startup-timing.ts
+++ b/src/node/desktop/src/main/startup-timing.ts
@@ -40,7 +40,15 @@ interface Checkpoint {
 
 // how long to wait after the workbench initializes before harvesting the
 // renderer timeline; long enough to include the deferred-init tail
-const kRendererHarvestDelayMs = 3000;
+// the harvest waits for the client's deferred-init-completed mark (the last
+// startup milestone), polling at this interval and giving up at the timeout
+// so a stalled session cannot postpone the harvest forever
+const kHarvestPollIntervalMs = 500;
+const kHarvestTimeoutMs = 30000;
+
+// once the final mark is seen, a short settle lets trailing entries (late
+// resource timings) be recorded before the timeline is copied
+const kHarvestSettleMs = 1000;
 
 // looked up on every checkpoint rather than cached: there are only a handful
 // of checkpoints, and this keeps the module trivially testable
@@ -104,13 +112,36 @@ interface RendererEntry {
 /**
  * Copies the renderer's navigation timing, resource timing and
  * `performance.mark()` entries into the timing file as "client" checkpoints.
- * The GWT client records marks prefixed "rstudio:" at its own milestones.
+ * The GWT client records marks prefixed "rstudio:" at its own milestones; the
+ * harvest runs once the last of them (deferred-init-completed) has been
+ * recorded, so slow launches are captured in full rather than truncated at a
+ * fixed delay.
  */
 export function harvestRendererTiming(webContents: WebContents): void {
   if (!startupTimingEnabled()) {
     return;
   }
 
+  const kProbeScript = String.raw`
+    performance.getEntriesByName('rstudio:deferred-init-completed', 'mark').length > 0`;
+
+  const deadline = Date.now() + kHarvestTimeoutMs;
+  const poll = () => {
+    webContents
+      .executeJavaScript(kProbeScript)
+      .then((completed: boolean) => {
+        if (completed || Date.now() >= deadline) {
+          setTimeout(() => harvestNow(webContents), kHarvestSettleMs);
+        } else {
+          setTimeout(poll, kHarvestPollIntervalMs);
+        }
+      })
+      .catch((error: unknown) => logger().logError(error));
+  };
+  setTimeout(poll, kHarvestPollIntervalMs);
+}
+
+function harvestNow(webContents: WebContents): void {
   // performance.timeOrigin is epoch-based, so everything can be converted to
   // the same wall-clock scale used by the other tiers
   const script = String.raw`
@@ -137,15 +168,13 @@ export function harvestRendererTiming(webContents: WebContents): void {
       return entries;
     })()`;
 
-  setTimeout(() => {
-    webContents
-      .executeJavaScript(script)
-      .then((entries: RendererEntry[]) => {
-        for (const entry of entries) {
-          write({ tier: 'client', name: entry.name, t: entry.t, dur: entry.dur });
-        }
-        write({ tier: 'desktop', name: 'timing-harvested', t: nowMs(), pid: process.pid });
-      })
-      .catch((error: unknown) => logger().logError(error));
-  }, kRendererHarvestDelayMs);
+  webContents
+    .executeJavaScript(script)
+    .then((entries: RendererEntry[]) => {
+      for (const entry of entries) {
+        write({ tier: 'client', name: entry.name, t: entry.t, dur: entry.dur });
+      }
+      write({ tier: 'desktop', name: 'timing-harvested', t: nowMs(), pid: process.pid });
+    })
+    .catch((error: unknown) => logger().logError(error));
 }

--- a/src/node/desktop/src/main/url-utils.ts
+++ b/src/node/desktop/src/main/url-utils.ts
@@ -84,6 +84,10 @@ export function isSafeHost(host: string): boolean {
   return false;
 }
 
+// a probe that connects but never receives a response (e.g. another process
+// shadowing the port) must not hang its caller's retry loop
+const kProbeRequestTimeoutMs = 2500;
+
 /**
  * Resolves true once something answers an HTTP request to `url` with any
  * status. The session's listener rejects this unauthenticated probe, but a
@@ -91,8 +95,8 @@ export function isSafeHost(host: string): boolean {
  */
 export async function probeUrl(url: string): Promise<boolean> {
   return new Promise((resolve) => {
-    http
-      .get(url, (res) => {
+    const request = http
+      .get(url, { timeout: kProbeRequestTimeoutMs }, (res) => {
         res.resume(); // consume response data to free up memory
         resolve(true);
       })
@@ -100,6 +104,10 @@ export async function probeUrl(url: string): Promise<boolean> {
         logger().logDebug(`Connection to ${url} failed: ${e.message}`);
         resolve(false);
       });
+    request.on('timeout', () => {
+      // destroying fires 'error' (ECONNRESET), which resolves false above
+      request.destroy();
+    });
   });
 }
 

--- a/src/node/desktop/src/main/url-utils.ts
+++ b/src/node/desktop/src/main/url-utils.ts
@@ -13,7 +13,6 @@
  *
  */
 
-import http from 'http';
 import { Err } from '../core/err';
 import { logger } from '../core/logger';
 import { WaitResult, WaitTimeoutFn, waitWithTimeout } from '../core/wait-utils';
@@ -94,21 +93,17 @@ const kProbeRequestTimeoutMs = 2500;
  * rejection still means it is up.
  */
 export async function probeUrl(url: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const request = http
-      .get(url, { timeout: kProbeRequestTimeoutMs }, (res) => {
-        res.resume(); // consume response data to free up memory
-        resolve(true);
-      })
-      .on('error', (e) => {
-        logger().logDebug(`Connection to ${url} failed: ${e.message}`);
-        resolve(false);
-      });
-    request.on('timeout', () => {
-      // destroying fires 'error' (ECONNRESET), which resolves false above
-      request.destroy();
+  try {
+    const response = await fetch(url, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(kProbeRequestTimeoutMs),
     });
-  });
+    await response.body?.cancel(); // release the connection without reading the body
+    return true;
+  } catch (error: unknown) {
+    logger().logDebug(`Connection to ${url} failed: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
 }
 
 /**

--- a/src/node/desktop/src/main/url-utils.ts
+++ b/src/node/desktop/src/main/url-utils.ts
@@ -85,6 +85,25 @@ export function isSafeHost(host: string): boolean {
 }
 
 /**
+ * Resolves true once something answers an HTTP request to `url` with any
+ * status. The session's listener rejects this unauthenticated probe, but a
+ * rejection still means it is up.
+ */
+export async function probeUrl(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    http
+      .get(url, (res) => {
+        res.resume(); // consume response data to free up memory
+        resolve(true);
+      })
+      .on('error', (e) => {
+        logger().logDebug(`Connection to ${url} failed: ${e.message}`);
+        resolve(false);
+      });
+  });
+}
+
+/**
  * Wait for a URL to respond, with retries and timeout
  */
 export async function waitForUrlWithTimeout(
@@ -94,17 +113,8 @@ export async function waitForUrlWithTimeout(
   maxWaitSec: number,
 ): Promise<Err> {
   const checkReady: WaitTimeoutFn = async () => {
-    return new Promise((resolve) => {
-      http
-        .get(url, (res) => {
-          res.resume(); // consume response data to free up memory
-          resolve(new WaitResult('WaitSuccess'));
-        })
-        .on('error', (e) => {
-          logger().logDebug(`Connection to ${url} failed: ${e.message}`);
-          resolve(new WaitResult('WaitContinue'));
-        });
-    });
+    const reachable = await probeUrl(url);
+    return new WaitResult(reachable ? 'WaitSuccess' : 'WaitContinue');
   };
 
   return waitWithTimeout(checkReady, initialWaitMs, incrementWaitMs, maxWaitSec);

--- a/src/node/desktop/test/unit/core/macho.test.ts
+++ b/src/node/desktop/test/unit/core/macho.test.ts
@@ -1,0 +1,58 @@
+/*
+ * macho.test.ts
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+import { machoArchitectures, readMachoArchitectures } from '../../../src/core/macho';
+
+function thin(cpuType: number): Buffer {
+  const buffer = Buffer.alloc(32);
+  buffer.writeUInt32LE(0xfeedfacf, 0);
+  buffer.writeUInt32LE(cpuType, 4);
+  return buffer;
+}
+
+function fat(cpuTypes: number[]): Buffer {
+  const buffer = Buffer.alloc(8 + 20 * cpuTypes.length);
+  buffer.writeUInt32BE(0xcafebabe, 0);
+  buffer.writeUInt32BE(cpuTypes.length, 4);
+  cpuTypes.forEach((cpuType, i) => buffer.writeUInt32BE(cpuType, 8 + 20 * i));
+  return buffer;
+}
+
+describe('macho', () => {
+  it('reads the architecture of a thin image', () => {
+    assert.deepEqual(machoArchitectures(thin(0x0100000c)), ['arm64']);
+    assert.deepEqual(machoArchitectures(thin(0x01000007)), ['x86_64']);
+  });
+
+  it('reads every slice of a universal image', () => {
+    assert.deepEqual(machoArchitectures(fat([0x01000007, 0x0100000c])), ['x86_64', 'arm64']);
+  });
+
+  it('ignores non-Mach-O content', () => {
+    assert.deepEqual(machoArchitectures(Buffer.from('#!/bin/sh\necho hi\n')), []);
+    assert.deepEqual(machoArchitectures(Buffer.alloc(0)), []);
+  });
+
+  it('reads a real image on macOS', function () {
+    if (process.platform !== 'darwin') {
+      this.skip();
+    }
+    const architectures = readMachoArchitectures('/bin/ls');
+    assert.isNotEmpty(architectures);
+    assert.include(['arm64', 'x86_64'], architectures[architectures.length - 1]);
+  });
+});

--- a/src/node/desktop/test/unit/main/detect-r.test.ts
+++ b/src/node/desktop/test/unit/main/detect-r.test.ts
@@ -21,9 +21,10 @@ import { join } from 'path';
 import { restore, saveAndClear } from '../unit-utils';
 import {
   detectREnvironment,
-  detectREnvironmentAsync,
   parseRQueryResult,
   promptUserForR,
+  rDetectionReady,
+  startRDetection,
 } from '../../../src/main/detect-r';
 
 describe('DetectR', () => {
@@ -82,9 +83,11 @@ describe('DetectR', () => {
     writeFileSync(fakeR, `#!/bin/sh\nprintf '\\036${fields.join('\\037')}'\n`, { mode: 0o755 });
 
     try {
-      const [background, backgroundError] = await detectREnvironmentAsync(fakeR);
-      assert.isNull(backgroundError);
-      assert.equal(background.envVars.R_HOME, '/opt/fake-r');
+      // the production wiring: main.ts starts the detection, and the launch
+      // sequence awaits it before the synchronous path reads the cache
+      process.env.RSTUDIO_WHICH_R = fakeR;
+      startRDetection();
+      await rDetectionReady();
 
       // remove the stand-in: another query would now fail to launch, so a
       // successful synchronous detection proves the cached result is reused
@@ -92,7 +95,8 @@ describe('DetectR', () => {
 
       const [environment, error] = detectREnvironment(fakeR);
       assert.isNull(error);
-      assert.deepEqual(environment, background);
+      assert.equal(environment.version, '4.5.1');
+      assert.equal(environment.envVars.R_HOME, '/opt/fake-r');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/node/desktop/test/unit/main/detect-r.test.ts
+++ b/src/node/desktop/test/unit/main/detect-r.test.ts
@@ -15,9 +15,16 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
-
-import { saveAndClear, restore } from '../unit-utils';
-import { promptUserForR } from '../../../src/main/detect-r';
+import { existsSync } from 'fs';
+import { restore, saveAndClear } from '../unit-utils';
+import {
+  detectREnvironment,
+  parseRQueryResult,
+  promptUserForR,
+  rDetectionReady,
+  scanForR,
+  startRDetection,
+} from '../../../src/main/detect-r';
 
 describe('DetectR', () => {
   const vars: Record<string, string> = {
@@ -38,5 +45,47 @@ describe('DetectR', () => {
     const [path, preflightError] = await promptUserForR(platform);
     assert.equal(path, null);
     assert.equal(preflightError?.message, 'This window can only be opened on Windows');
+  });
+
+  it('parses the output of the R query script', () => {
+    const fields = ['4.5.1', '/opt/R', '/opt/R/doc', '/opt/R/include', '/opt/R/share', '', '', '/opt/R/lib', 'aarch64-apple-darwin23'];
+    const stdout = 'Loading profile...\x1E' + fields.join('\x1F');
+
+    const [environment, error] = parseRQueryResult('/opt/R/bin/R', { stdout, stderr: '', status: 0 });
+    assert.isNull(error);
+    assert.equal(environment.version, '4.5.1');
+    assert.equal(environment.rScriptPath, '/opt/R/bin/R');
+    assert.equal(environment.envVars.R_HOME, '/opt/R');
+    assert.equal(environment.envVars.R_SHARE_DIR, '/opt/R/share');
+    assert.equal(environment.envVars.R_PLATFORM, 'aarch64-apple-darwin23');
+    assert.isTrue(environment.ldLibraryPath.endsWith('/opt/R/lib'));
+  });
+
+  it('rejects query output without the marker', () => {
+    const [, error] = parseRQueryResult('/opt/R/bin/R', { stdout: 'not R', stderr: '', status: 1 });
+    assert.isNotNull(error);
+
+    const [, noOutputError] = parseRQueryResult('/opt/R/bin/R', { stdout: '', stderr: '', status: 127 });
+    assert.isNotNull(noOutputError);
+  });
+
+  it('detects R in the background and serves the scan from the cache', async function () {
+    if (process.platform !== 'darwin' || !existsSync('/usr/local/bin/R')) {
+      this.skip();
+    }
+    this.timeout(30000);
+
+    startRDetection();
+    await rDetectionReady();
+
+    // the scan validates the same executable, so this must not need R again
+    const started = Date.now();
+    const [rPath, error] = scanForR();
+    assert.isNull(error);
+    assert.isTrue(existsSync(rPath));
+    const [environment, envError] = detectREnvironment(rPath);
+    assert.isNull(envError);
+    assert.isNotEmpty(environment.envVars.R_HOME);
+    assert.isBelow(Date.now() - started, 50, 'expected cached results, not a fresh R launch');
   });
 });

--- a/src/node/desktop/test/unit/main/detect-r.test.ts
+++ b/src/node/desktop/test/unit/main/detect-r.test.ts
@@ -15,15 +15,15 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
-import { existsSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { restore, saveAndClear } from '../unit-utils';
 import {
   detectREnvironment,
+  detectREnvironmentAsync,
   parseRQueryResult,
   promptUserForR,
-  rDetectionReady,
-  scanForR,
-  startRDetection,
 } from '../../../src/main/detect-r';
 
 describe('DetectR', () => {
@@ -69,23 +69,32 @@ describe('DetectR', () => {
     assert.isNotNull(noOutputError);
   });
 
-  it('detects R in the background and serves the scan from the cache', async function () {
-    if (process.platform !== 'darwin' || !existsSync('/usr/local/bin/R')) {
+  it('the background query fills the cache the synchronous path reads', async function () {
+    if (process.platform === 'win32') {
       this.skip();
     }
-    this.timeout(30000);
 
-    startRDetection();
-    await rDetectionReady();
+    // a stand-in R: an executable that answers the version query the way R
+    // would (\036 is the marker, \037 the field separator)
+    const fields = ['4.5.1', '/opt/fake-r', '/opt/fake-r/doc', '/opt/fake-r/include', '/opt/fake-r/share', '', '', '/opt/fake-r/lib', 'aarch64-fake'];
+    const dir = mkdtempSync(join(tmpdir(), 'detect-r-test-'));
+    const fakeR = join(dir, 'R');
+    writeFileSync(fakeR, `#!/bin/sh\nprintf '\\036${fields.join('\\037')}'\n`, { mode: 0o755 });
 
-    // the scan validates the same executable, so this must not need R again
-    const started = Date.now();
-    const [rPath, error] = scanForR();
-    assert.isNull(error);
-    assert.isTrue(existsSync(rPath));
-    const [environment, envError] = detectREnvironment(rPath);
-    assert.isNull(envError);
-    assert.isNotEmpty(environment.envVars.R_HOME);
-    assert.isBelow(Date.now() - started, 50, 'expected cached results, not a fresh R launch');
+    try {
+      const [background, backgroundError] = await detectREnvironmentAsync(fakeR);
+      assert.isNull(backgroundError);
+      assert.equal(background.envVars.R_HOME, '/opt/fake-r');
+
+      // remove the stand-in: another query would now fail to launch, so a
+      // successful synchronous detection proves the cached result is reused
+      rmSync(dir, { recursive: true, force: true });
+
+      const [environment, error] = detectREnvironment(fakeR);
+      assert.isNull(error);
+      assert.deepEqual(environment, background);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/node/desktop/test/unit/main/login-shell-path.test.ts
+++ b/src/node/desktop/test/unit/main/login-shell-path.test.ts
@@ -23,6 +23,7 @@ import {
   loginShellPath,
   resetLoginShellPath,
   startLoginShellPathQuery,
+  withDefaultToolPaths,
 } from '../../../src/main/login-shell-path';
 
 describe('LoginShellPath', () => {
@@ -75,5 +76,15 @@ describe('LoginShellPath', () => {
     startLoginShellPathQuery(dir);
     assert.equal(cachedLoginShellPath(), fresh);
     assert.equal(await loginShellPath(), fresh);
+  });
+
+  it('extends a PATH with the standard tool locations, without duplicates', () => {
+    const extended = withDefaultToolPaths('/usr/bin:/opt/homebrew/bin');
+    const parts = extended.split(':');
+
+    assert.equal(parts[0], '/usr/bin');
+    assert.include(parts, '/usr/local/bin');
+    assert.include(parts, '/opt/homebrew/bin');
+    assert.equal(new Set(parts).size, parts.length, 'expected no duplicate entries');
   });
 });

--- a/src/node/desktop/test/unit/main/login-shell-path.test.ts
+++ b/src/node/desktop/test/unit/main/login-shell-path.test.ts
@@ -78,13 +78,23 @@ describe('LoginShellPath', () => {
     assert.equal(await loginShellPath(), fresh);
   });
 
-  it('extends a PATH with the standard tool locations, without duplicates', () => {
-    const extended = withDefaultToolPaths('/usr/bin:/opt/homebrew/bin');
+  it('builds a fallback PATH with tool locations first, without duplicates', () => {
+    const extended = withDefaultToolPaths('/usr/bin:/opt/homebrew/bin:/custom/bin');
     const parts = extended.split(':');
 
-    assert.equal(parts[0], '/usr/bin');
     assert.include(parts, '/usr/local/bin');
     assert.include(parts, '/opt/homebrew/bin');
+    assert.include(parts, '/custom/bin');
     assert.equal(new Set(parts).size, parts.length, 'expected no duplicate entries');
+
+    // the path_helper entries take precedence over inherited ones, as they
+    // would in a real login shell
+    if (process.platform === 'darwin') {
+      assert.isBelow(
+        parts.indexOf('/usr/local/bin'),
+        parts.indexOf('/custom/bin'),
+        'expected path_helper entries to precede inherited ones',
+      );
+    }
   });
 });

--- a/src/node/desktop/test/unit/main/login-shell-path.test.ts
+++ b/src/node/desktop/test/unit/main/login-shell-path.test.ts
@@ -20,6 +20,7 @@ import { tmpdir } from 'os';
 import path from 'path';
 import {
   cachedLoginShellPath,
+  isShellDerivedPath,
   loginShellPath,
   resetLoginShellPath,
   startLoginShellPathQuery,
@@ -76,6 +77,21 @@ describe('LoginShellPath', () => {
     startLoginShellPathQuery(dir);
     assert.equal(cachedLoginShellPath(), fresh);
     assert.equal(await loginShellPath(), fresh);
+  });
+
+  it('recognizes a shell-derived PATH by /usr/local/bin, as the session does', () => {
+    // a terminal launch: the shell's PATH (possibly customized) must be kept
+    assert.isTrue(isShellDerivedPath('/usr/local/bin:/usr/bin:/bin'));
+    assert.isTrue(isShellDerivedPath('/opt/conda/envs/myenv/bin:/usr/local/bin:/usr/bin'));
+    assert.isTrue(isShellDerivedPath('/usr/bin:/usr/local/bin'));
+    assert.isTrue(isShellDerivedPath('/usr/bin:/usr/local/bin/:/bin'));
+
+    // a Finder / Dock launch: launchd's minimal PATH
+    assert.isFalse(isShellDerivedPath('/usr/bin:/bin:/usr/sbin:/sbin'));
+    assert.isFalse(isShellDerivedPath(''));
+
+    // entries merely prefixed with /usr/local/bin do not count
+    assert.isFalse(isShellDerivedPath('/usr/local/binaries:/usr/bin'));
   });
 
   it('builds a fallback PATH with tool locations first, without duplicates', () => {

--- a/src/node/desktop/test/unit/main/login-shell-path.test.ts
+++ b/src/node/desktop/test/unit/main/login-shell-path.test.ts
@@ -1,0 +1,79 @@
+/*
+ * login-shell-path.test.ts
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import {
+  cachedLoginShellPath,
+  loginShellPath,
+  resetLoginShellPath,
+  startLoginShellPathQuery,
+} from '../../../src/main/login-shell-path';
+
+describe('LoginShellPath', () => {
+  let dir: string;
+  const savedShell = process.env.RSTUDIO_SESSION_SHELL;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'login-shell-path-'));
+    resetLoginShellPath();
+  });
+
+  afterEach(() => {
+    resetLoginShellPath();
+    rmSync(dir, { recursive: true, force: true });
+    if (savedShell === undefined) {
+      delete process.env.RSTUDIO_SESSION_SHELL;
+    } else {
+      process.env.RSTUDIO_SESSION_SHELL = savedShell;
+    }
+  });
+
+  it('knows nothing before a query has run', async () => {
+    assert.isNull(cachedLoginShellPath());
+    assert.isNull(await loginShellPath());
+  });
+
+  it('waits for the shell on a first launch, then remembers its answer', async function () {
+    if (process.platform !== 'darwin') {
+      this.skip();
+    }
+    this.timeout(15000);
+
+    // /bin/sh -l reads /etc/profile, which is enough to produce a PATH
+    process.env.RSTUDIO_SESSION_SHELL = '/bin/sh';
+
+    startLoginShellPathQuery(dir);
+    assert.isNull(cachedLoginShellPath(), 'nothing is known on a first launch');
+
+    const fresh = await loginShellPath();
+    assert.isNotNull(fresh);
+    assert.include(fresh, '/usr/bin');
+    assert.equal(cachedLoginShellPath(), fresh);
+
+    const stateFile = path.join(dir, 'startup-state.json');
+    assert.isTrue(existsSync(stateFile));
+    assert.include(readFileSync(stateFile, 'utf8'), '/usr/bin');
+
+    // a later launch has last time's answer before the shell replies
+    resetLoginShellPath();
+    startLoginShellPathQuery(dir);
+    assert.equal(cachedLoginShellPath(), fresh);
+    assert.equal(await loginShellPath(), fresh);
+  });
+});

--- a/src/node/desktop/test/unit/main/startup-timing.test.ts
+++ b/src/node/desktop/test/unit/main/startup-timing.test.ts
@@ -1,0 +1,70 @@
+/*
+ * startup-timing.test.ts
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { startupCheckpoint, startupTimingEnabled } from '../../../src/main/startup-timing';
+
+describe('StartupTiming', () => {
+  let dir: string;
+  let file: string;
+  const savedEnv = process.env.RSTUDIO_STARTUP_TIMING;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'startup-timing-'));
+    file = path.join(dir, 'timing.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (savedEnv === undefined) {
+      delete process.env.RSTUDIO_STARTUP_TIMING;
+    } else {
+      process.env.RSTUDIO_STARTUP_TIMING = savedEnv;
+    }
+  });
+
+  it('is disabled and writes nothing when RSTUDIO_STARTUP_TIMING is unset', () => {
+    delete process.env.RSTUDIO_STARTUP_TIMING;
+    assert.isFalse(startupTimingEnabled());
+    startupCheckpoint('unused');
+    assert.isFalse(existsSync(file));
+  });
+
+  it('appends one JSON line per checkpoint when enabled', () => {
+    process.env.RSTUDIO_STARTUP_TIMING = file;
+    assert.isTrue(startupTimingEnabled());
+
+    const before = Date.now();
+    startupCheckpoint('first');
+    startupCheckpoint('second');
+
+    const lines = readFileSync(file, 'utf8').trim().split('\n');
+    assert.lengthOf(lines, 2);
+
+    const first = JSON.parse(lines[0]);
+    const second = JSON.parse(lines[1]);
+    assert.deepEqual(
+      [first.tier, first.name, first.pid],
+      ['desktop', 'first', process.pid],
+    );
+    assert.equal(second.name, 'second');
+    assert.isAtLeast(first.t, before - 1);
+    assert.isAtLeast(second.t, first.t);
+  });
+});

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -6,6 +6,7 @@ Repo-level developer tasks, run through the top-level `package.json`:
 npm run rserver-dev       # start a development RStudio Server
 npm run rserver-status    # report what is running
 npm run rserver-stop      # stop it
+npm run startup-timing    # measure RStudio Desktop startup
 ```
 
 The tasks are TypeScript run directly by `node` (built-in type stripping, Node
@@ -60,6 +61,44 @@ reports the running instance instead (use `--restart` to replace it).
 - State lives in `<checkout>/.rstudio-dev/` (gitignored): `instance.json` plus
   `rserver.log` and `gwt.log`, which are the first place to look if a start
   fails.
+
+## startup-timing
+
+Measures where RStudio Desktop spends its startup time:
+
+```sh
+npm run startup-timing                                   # dev build, 3 launches
+npm run startup-timing -- --runs=5 --no-splash
+npm run startup-timing -- --app=/Applications/RStudio.app/Contents/MacOS/RStudio
+npm run startup-timing -- --report=.rstudio-dev/startup-timing   # re-print
+```
+
+Each launch runs with `RSTUDIO_STARTUP_TIMING=<file>`, which makes the three
+processes involved append checkpoints to one JSON-lines file:
+
+- the Electron main process (`src/node/desktop/src/main/startup-timing.ts`):
+  app ready, R detection, rsession spawn, window creation, page load,
+  workbench initialized;
+- the rsession process (`src/cpp/core/StartupTiming.cpp`, called from
+  `SessionMain.cpp`, `RInit.cpp` and friends): options, prefs, HTTP listener,
+  R initialization, module initialization, `client_init`, deferred init;
+- the GWT client, which records `performance.mark("rstudio:...")` at its own
+  milestones (`org.rstudio.core.client.StartupTiming`); the desktop copies
+  those marks plus the navigation and resource timings into the file once the
+  workbench is up.
+
+The report prints the merged timeline (medians across runs, relative to the
+Electron process creation time) followed by the longest measured spans, such
+as the R module files sourced during session init and the largest downloads.
+The per-run files under `<checkout>/.rstudio-dev/startup-timing/` also hold
+the launch log and, unless `--user-config` was given, the throwaway RStudio
+config and data homes the run used. The Electron profile (`--user-data-dir`)
+is shared by the runs of one measurement and emptied before the first, so
+run 1 behaves like a first launch and later runs like everyday launches.
+
+Measuring the dev build goes through `npm run start` (electron-forge) each
+time, so a run takes a while to start; the timeline is unaffected because it
+begins at Electron process creation, after webpack has finished.
 
 ## Windows
 

--- a/tasks/common.ts
+++ b/tasks/common.ts
@@ -138,9 +138,10 @@ export function flagNumber(tag: string, args: ParsedArgs, name: string): number 
  * -- and, deliberately, severs the data flow from the command line to the file
  * operations downstream, which the Snyk Code scan otherwise reports as path
  * traversal (a developer pointing a developer tool at their own checkout is
- * not an attack, but there is no way to suppress the finding).
+ * not an attack, but there is no way to suppress the finding). Tasks that
+ * accept other path arguments (e.g. --out, --report) launder them the same way.
  */
-function rebuildFromDirectoryListings(tag: string, dir: string): string {
+export function rebuildFromDirectoryListings(tag: string, dir: string): string {
   let result = '/';
 
   for (const segment of dir.split('/')) {

--- a/tasks/startup-timing.ts
+++ b/tasks/startup-timing.ts
@@ -177,13 +177,19 @@ async function launchOnce(index: number, options: LaunchOptions): Promise<Run> {
     exited = true;
   });
 
-  // the desktop writes 'timing-harvested' a few seconds after the workbench
-  // initializes, once the renderer's timeline has been copied into the file
+  // the desktop writes 'timing-harvested' once the client reports deferred
+  // init complete and the renderer's timeline has been copied into the file
+  // (or 'timing-harvest-timeout' if the client never got that far)
   const deadline = Date.now() + options.timeoutMs;
   let complete = false;
+  let harvestTimedOut = false;
   while (Date.now() < deadline) {
     if (hasCheckpoint(timingFile, 'timing-harvested')) {
       complete = true;
+      break;
+    }
+    if (hasCheckpoint(timingFile, 'timing-harvest-timeout')) {
+      harvestTimedOut = true;
       break;
     }
     if (exited) {
@@ -198,7 +204,11 @@ async function launchOnce(index: number, options: LaunchOptions): Promise<Run> {
   await waitForExit(pid, 5000);
 
   if (!complete) {
-    const reason = exited ? 'the process exited before the workbench initialized' : 'timed out';
+    const reason = harvestTimedOut
+      ? 'the client never completed deferred init, so the timeline is incomplete'
+      : exited
+        ? 'the process exited before the workbench initialized'
+        : 'timed out';
     fail(TAG, `run ${index + 1}: ${reason}; see ${logFile}`);
   }
 

--- a/tasks/startup-timing.ts
+++ b/tasks/startup-timing.ts
@@ -1,0 +1,415 @@
+// Measure RStudio Desktop startup.
+//
+//     npm run startup-timing -- [<checkout>] [--runs=N] [--app=<binary>]
+//
+// Launches RStudio Desktop several times with RSTUDIO_STARTUP_TIMING set, so
+// the Electron main process, the rsession process and the GWT client all
+// append their startup checkpoints to one JSON-lines file per run, then prints
+// a merged timeline (medians across runs) and the longest measured spans.
+//
+// By default each run gets a fresh config/data home and Electron user-data
+// directory, so the numbers describe a clean start rather than whatever
+// project or documents happened to be open last; --user-config measures the
+// real profile instead.
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  fail,
+  findFreePort,
+  flagNumber,
+  parseArgs,
+  rejectUnknownFlags,
+  requirePosix,
+  resolveCheckout,
+  signalProcess,
+  sleep,
+  stateDir,
+  step,
+  waitForExit,
+} from './common.ts';
+
+const TAG = 'startup-timing';
+
+const KNOWN_FLAGS = ['path', 'runs', 'app', 'out', 'report', 'user-config', 'splash', 'extra', 'timeout', 'help'];
+
+const USAGE = `
+Usage: npm run startup-timing -- [<checkout>] [options]
+
+Launches RStudio Desktop repeatedly and reports where startup time goes.
+
+Options:
+  --path=<dir>       Checkout to launch the dev build from (default: this one)
+  --runs=<n>         Number of launches to measure (default 3)
+  --app=<binary>     Measure an installed build instead of the dev build,
+                     e.g. /Applications/RStudio.app/Contents/MacOS/RStudio
+  --out=<dir>        Where per-run files go (default <checkout>/.rstudio-dev/startup-timing)
+  --report=<path>    Skip launching; report on an existing .jsonl file or a
+                     directory of run-*/ folders produced by an earlier run
+  --user-config      Use the real user config, data and Electron profile
+                     (default: a fresh temporary profile per run)
+  --no-splash        Suppress the splash screen (RS_NO_SPLASH=1)
+  --extra=<args>     Extra command-line arguments for RStudio (space separated)
+  --timeout=<sec>    Give up on a launch after this long (default 120)
+  --help             Show this message
+`.trim();
+
+interface Checkpoint {
+  tier: string;
+  name: string;
+  t: number;
+  pid?: number;
+  dur?: number;
+}
+
+interface Run {
+  file: string;
+  checkpoints: Checkpoint[];
+}
+
+// --- launching --------------------------------------------------------------
+
+interface LaunchOptions {
+  checkout: string;
+  app: string | null;
+  outDir: string;
+  userConfig: boolean;
+  splash: boolean;
+  extraArgs: string[];
+  timeoutMs: number;
+}
+
+function devBuildOutput(checkout: string): string | null {
+  const configured = path.join(checkout, 'build', 'CMakeCache.txt');
+  if (fs.existsSync(configured)) {
+    return path.join(checkout, 'build', 'src', 'cpp');
+  }
+
+  // a worktree bootstrapped without its own C++ build (see
+  // scripts/bootstrap-worktree.sh) serves the main checkout's rsession
+  const shim = path.join(checkout, 'build-dev-shim');
+  if (fs.existsSync(path.join(shim, 'conf', 'rdesktop-dev.conf'))) {
+    return shim;
+  }
+
+  return null;
+}
+
+function hasCheckpoint(file: string, name: string): boolean {
+  try {
+    return fs.readFileSync(file, 'utf8').includes(`"name":"${name}"`);
+  } catch {
+    return false;
+  }
+}
+
+async function launchOnce(index: number, options: LaunchOptions): Promise<Run> {
+  const runDir = path.join(options.outDir, `run-${String(index + 1).padStart(2, '0')}`);
+  fs.rmSync(runDir, { recursive: true, force: true });
+  fs.mkdirSync(runDir, { recursive: true });
+
+  const timingFile = path.join(runDir, 'startup-timing.jsonl');
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    RSTUDIO_STARTUP_TIMING: timingFile,
+    RSTUDIO_DISABLE_WHATS_NEW: '1',
+  };
+  if (!options.splash) {
+    env.RS_NO_SPLASH = '1';
+  }
+
+  const args: string[] = [];
+  if (!options.userConfig) {
+    const configHome = path.join(runDir, 'config-home');
+    const dataHome = path.join(runDir, 'data-home');
+    for (const dir of [configHome, dataHome]) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    env.RSTUDIO_CONFIG_HOME = configHome;
+    env.RSTUDIO_DATA_HOME = dataHome;
+
+    // the Electron profile is shared by the runs of one measurement (and
+    // emptied before the first), so run 1 is a first launch and the rest
+    // see whatever the desktop remembers between launches
+    const userData = path.join(options.outDir, 'electron-userdata');
+    if (index === 0) {
+      fs.rmSync(userData, { recursive: true, force: true });
+    }
+    fs.mkdirSync(userData, { recursive: true });
+    args.push(`--user-data-dir=${userData}`);
+  }
+  args.push(...options.extraArgs);
+
+  let child: ChildProcess;
+  const logFile = path.join(runDir, 'launch.log');
+  const log = fs.openSync(logFile, 'w');
+  if (options.app) {
+    child = spawn(options.app, args, { env, detached: true, stdio: ['ignore', log, log] });
+  } else {
+    const buildOutput = devBuildOutput(options.checkout);
+    if (buildOutput === null) {
+      fail(TAG, `${options.checkout} has no C++ build (build/) or dev shim (build-dev-shim); build it first`);
+    }
+    env.RSTUDIO_CPP_BUILD_OUTPUT = buildOutput;
+
+    // electron-forge's webpack dev server and logger default to fixed ports
+    // (3000 / 9000); pick free ones so a developer's own dev instance, or
+    // an e2e run, can coexist with the measurement (forge.config.js reads these)
+    env.RSTUDIO_DESKTOP_DEV_PORT = String(await findFreePort(TAG, 3100, '0.0.0.0'));
+    env.RSTUDIO_DESKTOP_LOGGER_PORT = String(await findFreePort(TAG, 9100, '0.0.0.0'));
+    child = spawn('npm', ['run', 'start', '--', ...args], {
+      cwd: path.join(options.checkout, 'src', 'node', 'desktop'),
+      env,
+      detached: true,
+      stdio: ['ignore', log, log],
+    });
+  }
+  fs.closeSync(log);
+
+  const pid = child.pid;
+  if (pid === undefined) {
+    fail(TAG, 'failed to launch RStudio');
+  }
+
+  let exited = false;
+  child.on('exit', () => {
+    exited = true;
+  });
+
+  // the desktop writes 'timing-harvested' a few seconds after the workbench
+  // initializes, once the renderer's timeline has been copied into the file
+  const deadline = Date.now() + options.timeoutMs;
+  let complete = false;
+  while (Date.now() < deadline) {
+    if (hasCheckpoint(timingFile, 'timing-harvested')) {
+      complete = true;
+      break;
+    }
+    if (exited) {
+      break;
+    }
+    await sleep(100);
+  }
+
+  // the child is a process-group leader (detached), so this takes down the
+  // renderer/GPU helpers and rsession with it; in dev mode, electron-forge too
+  signalProcess(pid, 'SIGKILL', true);
+  await waitForExit(pid, 5000);
+
+  if (!complete) {
+    const reason = exited ? 'the process exited before the workbench initialized' : 'timed out';
+    fail(TAG, `run ${index + 1}: ${reason}; see ${logFile}`);
+  }
+
+  return readRun(timingFile);
+}
+
+// --- reading ----------------------------------------------------------------
+
+function readRun(file: string): Run {
+  const checkpoints: Checkpoint[] = [];
+  for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      checkpoints.push(JSON.parse(line) as Checkpoint);
+    } catch {
+      // a torn line from a process killed mid-write; skip it
+    }
+  }
+  checkpoints.sort((a, b) => a.t - b.t);
+  return { file, checkpoints };
+}
+
+function readRuns(target: string): Run[] {
+  if (fs.statSync(target).isFile()) {
+    return [readRun(target)];
+  }
+
+  const runs: Run[] = [];
+  for (const entry of fs.readdirSync(target).sort()) {
+    const file = path.join(target, entry, 'startup-timing.jsonl');
+    if (fs.existsSync(file)) {
+      runs.push(readRun(file));
+    }
+  }
+  if (runs.length === 0) {
+    fail(TAG, `no startup-timing.jsonl files found under ${target}`);
+  }
+  return runs;
+}
+
+// --- reporting --------------------------------------------------------------
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function pad(value: string | number, width: number): string {
+  return String(value).padStart(width);
+}
+
+/** Everything is reported relative to the Electron process creation time. */
+function origin(run: Run): number {
+  const start = run.checkpoints.find((c) => c.tier === 'desktop' && c.name === 'process-start');
+  return start ? start.t : run.checkpoints[0].t;
+}
+
+function key(checkpoint: Checkpoint): string {
+  return `${checkpoint.tier}:${checkpoint.name}`;
+}
+
+// resource entries are numerous and only interesting by duration; the
+// navigation timing and client marks tell the story of the page load
+function isTimelineEntry(checkpoint: Checkpoint): boolean {
+  return checkpoint.dur === undefined && !checkpoint.name.startsWith('resource:');
+}
+
+function report(runs: Run[]): void {
+  console.log('');
+  console.log(`Runs: ${runs.length}`);
+  for (const [index, run] of runs.entries()) {
+    const t0 = origin(run);
+    const summary: string[] = [];
+    for (const [tier, name] of [
+      ['session', 'first-wait-for-method'],
+      ['client', 'workbench-painted'],
+      ['session', 'deferred-init-completed'],
+    ]) {
+      const found = run.checkpoints.find((c) => c.tier === tier && c.name === name);
+      if (found) {
+        summary.push(`${name} ${Math.round(found.t - t0)} ms`);
+      }
+    }
+    console.log(`  run ${index + 1}: ${summary.join(', ')}  (${run.file})`);
+  }
+
+  // timeline: median time of each checkpoint across the runs it appears in
+  const times = new Map<string, number[]>();
+  const seen = new Map<string, Checkpoint>();
+  for (const run of runs) {
+    const t0 = origin(run);
+    for (const checkpoint of run.checkpoints) {
+      if (!isTimelineEntry(checkpoint)) {
+        continue;
+      }
+      const k = key(checkpoint);
+      if (!times.has(k)) {
+        times.set(k, []);
+        seen.set(k, checkpoint);
+      }
+      times.get(k)!.push(checkpoint.t - t0);
+    }
+  }
+
+  const rows = [...times.entries()]
+    .map(([k, values]) => ({ checkpoint: seen.get(k)!, t: median(values), n: values.length }))
+    .sort((a, b) => a.t - b.t);
+
+  console.log('');
+  console.log(`Timeline (median ms since Electron process start${runs.length > 1 ? `, ${runs.length} runs` : ''})`);
+  console.log('');
+  console.log(`  ${pad('t', 7)}  ${pad('+delta', 7)}  ${'tier'.padEnd(8)} checkpoint`);
+  let previous = 0;
+  for (const row of rows) {
+    const delta = row.t - previous;
+    previous = row.t;
+    const missing = row.n < runs.length ? `  (${row.n}/${runs.length} runs)` : '';
+    console.log(
+      `  ${pad(Math.round(row.t), 7)}  ${pad(Math.round(delta), 7)}  ${row.checkpoint.tier.padEnd(8)} ${row.checkpoint.name}${missing}`,
+    );
+  }
+
+  // spans: anything reported with a duration, longest first
+  const durations = new Map<string, number[]>();
+  for (const run of runs) {
+    for (const checkpoint of run.checkpoints) {
+      if (checkpoint.dur === undefined) {
+        continue;
+      }
+      const k = key(checkpoint);
+      if (!durations.has(k)) {
+        durations.set(k, []);
+      }
+      durations.get(k)!.push(checkpoint.dur);
+    }
+  }
+
+  const spans = [...durations.entries()]
+    .map(([k, values]) => ({ key: k, dur: median(values) }))
+    .sort((a, b) => b.dur - a.dur)
+    .slice(0, 25);
+
+  if (spans.length > 0) {
+    console.log('');
+    console.log('Longest spans (median ms)');
+    console.log('');
+    for (const span of spans) {
+      const [tier, ...rest] = span.key.split(':');
+      console.log(`  ${pad(Math.round(span.dur), 7)}  ${tier.padEnd(8)} ${rest.join(':')}`);
+    }
+  }
+  console.log('');
+}
+
+// --- main -------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.flags.get('help') === true) {
+    console.log(USAGE);
+    return;
+  }
+  rejectUnknownFlags(TAG, args, KNOWN_FLAGS);
+
+  const reportTarget = args.flags.get('report');
+  if (typeof reportTarget === 'string') {
+    report(readRuns(path.resolve(reportTarget)));
+    return;
+  }
+
+  requirePosix(TAG);
+
+  const explicit = args.positional[0] ?? (args.flags.get('path') as string | undefined);
+  const checkout = resolveCheckout(TAG, explicit);
+  const runs = flagNumber(TAG, args, 'runs') ?? 3;
+  const timeoutSec = flagNumber(TAG, args, 'timeout') ?? 120;
+  const app = args.flags.get('app');
+  const out = args.flags.get('out');
+  const extra = args.flags.get('extra');
+
+  const options: LaunchOptions = {
+    checkout,
+    app: typeof app === 'string' ? path.resolve(app) : null,
+    outDir: typeof out === 'string' ? path.resolve(out) : path.join(stateDir(checkout), 'startup-timing'),
+    userConfig: args.flags.get('user-config') === true,
+    splash: args.flags.get('splash') !== false,
+    extraArgs: typeof extra === 'string' ? extra.split(' ').filter((a) => a.length > 0) : [],
+    timeoutMs: timeoutSec * 1000,
+  };
+
+  if (options.app !== null && !fs.existsSync(options.app)) {
+    fail(TAG, `no such file: ${options.app}`);
+  }
+
+  fs.mkdirSync(options.outDir, { recursive: true });
+  step(TAG, `Measuring ${options.app ?? `the dev build in ${checkout}`} (${runs} run${runs === 1 ? '' : 's'})`);
+  step(TAG, `Per-run files under ${options.outDir}`);
+
+  const results: Run[] = [];
+  for (let i = 0; i < runs; i++) {
+    step(TAG, `run ${i + 1}/${runs}...`);
+    results.push(await launchOnce(i, options));
+
+    // let the OS reclaim the killed processes before the next launch
+    await sleep(1500);
+  }
+
+  report(results);
+}
+
+await main();

--- a/tasks/startup-timing.ts
+++ b/tasks/startup-timing.ts
@@ -20,6 +20,7 @@ import {
   findFreePort,
   flagNumber,
   parseArgs,
+  rebuildFromDirectoryListings,
   rejectUnknownFlags,
   requirePosix,
   resolveCheckout,
@@ -378,7 +379,11 @@ async function main(): Promise<void> {
 
   const reportTarget = args.flags.get('report');
   if (typeof reportTarget === 'string') {
-    report(readRuns(path.resolve(reportTarget)));
+    const resolved = path.resolve(reportTarget);
+    if (!fs.existsSync(resolved)) {
+      fail(TAG, `no such file or directory: ${resolved}`);
+    }
+    report(readRuns(rebuildFromDirectoryListings(TAG, fs.realpathSync(resolved))));
     return;
   }
 
@@ -392,19 +397,34 @@ async function main(): Promise<void> {
   const out = args.flags.get('out');
   const extra = args.flags.get('extra');
 
+  // like the checkout, paths from the command line are laundered through
+  // directory listings before they reach file operations or spawn
+  // (see rebuildFromDirectoryListings)
+  let appBinary: string | null = null;
+  if (typeof app === 'string') {
+    const resolved = path.resolve(app);
+    if (!fs.existsSync(resolved)) {
+      fail(TAG, `no such file: ${resolved}`);
+    }
+    appBinary = rebuildFromDirectoryListings(TAG, fs.realpathSync(resolved));
+  }
+
+  let outDir = path.join(stateDir(checkout), 'startup-timing');
+  if (typeof out === 'string') {
+    const resolved = path.resolve(out);
+    fs.mkdirSync(resolved, { recursive: true });
+    outDir = rebuildFromDirectoryListings(TAG, fs.realpathSync(resolved));
+  }
+
   const options: LaunchOptions = {
     checkout,
-    app: typeof app === 'string' ? path.resolve(app) : null,
-    outDir: typeof out === 'string' ? path.resolve(out) : path.join(stateDir(checkout), 'startup-timing'),
+    app: appBinary,
+    outDir,
     userConfig: args.flags.get('user-config') === true,
     splash: args.flags.get('splash') !== false,
     extraArgs: typeof extra === 'string' ? extra.split(' ').filter((a) => a.length > 0) : [],
     timeoutMs: timeoutSec * 1000,
   };
-
-  if (options.app !== null && !fs.existsSync(options.app)) {
-    fail(TAG, `no such file: ${options.app}`);
-  }
 
   fs.mkdirSync(options.outDir, { recursive: true });
   step(TAG, `Measuring ${options.app ?? `the dev build in ${checkout}`} (${runs} run${runs === 1 ? '' : 's'})`);

--- a/tasks/startup-timing.ts
+++ b/tasks/startup-timing.ts
@@ -235,21 +235,30 @@ function readRun(file: string): Run {
 }
 
 function readRuns(target: string): Run[] {
-  if (fs.statSync(target).isFile()) {
-    return [readRun(target)];
-  }
-
   const runs: Run[] = [];
-  for (const entry of fs.readdirSync(target).sort()) {
-    const file = path.join(target, entry, 'startup-timing.jsonl');
-    if (fs.existsSync(file)) {
-      runs.push(readRun(file));
+  if (fs.statSync(target).isFile()) {
+    runs.push(readRun(target));
+  } else {
+    for (const entry of fs.readdirSync(target).sort()) {
+      const file = path.join(target, entry, 'startup-timing.jsonl');
+      if (fs.existsSync(file)) {
+        runs.push(readRun(file));
+      }
     }
   }
-  if (runs.length === 0) {
-    fail(TAG, `no startup-timing.jsonl files found under ${target}`);
+
+  // a launch killed before its first checkpoint leaves an empty file behind;
+  // such a run has no timeline (and no origin) to report
+  const nonEmpty = runs.filter((run) => run.checkpoints.length > 0);
+  for (const run of runs) {
+    if (!nonEmpty.includes(run)) {
+      step(TAG, `skipping ${run.file}: no checkpoints`);
+    }
   }
-  return runs;
+  if (nonEmpty.length === 0) {
+    fail(TAG, `no startup checkpoints found under ${target}`);
+  }
+  return nonEmpty;
 }
 
 // --- reporting --------------------------------------------------------------


### PR DESCRIPTION
### Intent

Make RStudio Desktop start faster, and make it possible to see where startup time goes so future changes can be measured rather than guessed at.

Measured as a matched pair on this machine (Apple silicon, dev build, fresh config and data home per run; the baseline is the timing-instrumentation commit alone, built in its own worktree, with both series run back-to-back under the same ambient load): with the full branch the workbench paints at a median of 1,927 ms after Electron process creation versus 3,627 ms for the baseline (47% faster), and a first launch after install goes from 5.6 s to 2.6 s (53% faster). Absolute numbers track machine load -- an earlier pair measured on a quieter machine mid-branch came out 2,511 ms -> 1,279 ms with the same ratio.

### Approach

Two waves of commits, intended to be reviewed separately. The first four groups instrument startup and fix the desktop/session sides; a second wave (commits from `install the initial gwt fragment...` on) addresses the client side, guided by Chromium startup traces of the renderer.

**1. Startup timing checkpoints.** With `RSTUDIO_STARTUP_TIMING=<file>` set, the Electron main process, `rsession`, and the GWT client each append JSON-line checkpoints to that file, giving one timeline across all three processes. `npm run startup-timing -- --runs=N` (a new task in `tasks/`) launches the app repeatedly and prints the merged timeline as medians plus the longest spans; `--app=<binary>` measures an installed build, `--report=<dir>` re-prints. The client's checkpoints are `performance.mark("rstudio:...")` entries, so they also show up in the DevTools Performance panel. Zero cost when the variable is unset.

**2. Desktop launch sequence** (`src/node/desktop`):
- R was queried twice for the same executable, plus two `/usr/bin/file` calls; detection results are cached per executable and the Mach-O header is read directly.
- On macOS, rsession ran the user's login shell to recover PATH at the start of every launch (~550 ms on this machine, entirely on the critical path). The desktop now asks the shell at the top of `main.ts` and passes the answer to rsession with `RSTUDIO_SESSION_PATH_INITIALIZED=1`, so the session skips its own query. If the shell has not answered by launch time, the previous launch's answer (kept in the desktop's state store) is used and the fresh one is remembered for next time; only a first launch with nothing remembered waits. Machines with a fast profile therefore always get a fresh PATH; on slow profiles a changed profile applies from the following launch.
- The main window navigated before the session was listening, failed, showed the loading page, and polled at 200 ms intervals. It now shows the loading page first and navigates as soon as a 20 ms probe finds the listener up.

**3. Query R while Electron is still starting** (`src/node/desktop`). Detecting R means running it (~150 ms), and startup did that only once it needed the answer. The query now starts at the top of `main.ts` and fills the same cache the synchronous path reads, trying the executables startup would pick anyway and stopping at the first that answers. Choosing candidates and parsing the query output are now shared with the synchronous path instead of duplicated. R detection no longer appears on the critical path: it resolves about 1 ms after the launch sequence asks, and the session spawns roughly 135 ms earlier.

**4. Session serves the client during R init** (`src/cpp`):
- The GWT file handler is registered before the http listener starts, and static GET requests that fall through to it (the page, scripts, styles) are handed by the listener thread to a dedicated static-asset thread. The client loads while R initializes; the first request the main thread sees is `client_init`. Measured alone this saved ~440 ms.
- Files served in desktop mode are no longer runtime-gzipped: deflating the 6.8 MB permutation cost 161 ms per launch over loopback; it now takes 29 ms to serve. Server mode keeps runtime compression for files without a precompressed variant.
- The large content-hashed GWT outputs (`*.cache.js` / `*.cache.css`) are now gzipped once at build time (`tools/precompress.js`, run from the `gwtc` ant target), and the file handler serves the `.gz` sibling with `Content-Encoding: gzip` whenever the client accepts it -- in both desktop and server modes, since a precompressed file costs nothing to serve and reads less disk. Server mode stops re-deflating the same immutable assets on every first load.

Baseline budget and the ranked remaining opportunities (desktop main-thread work delaying the probe by ~200 ms, the serialized `set_user_state`/`set_user_prefs` round trips before `initializeWorkbench`, a stable per-user port so Chromium's caches survive launches, lazy quarto/git init) are written up in the profiling report; happy to file follow-ups.

**5. Client-side wave** (`src/gwt`), from renderer trace analysis:
- The GWT permutation was delivered as string literals and installed via eval (the xsiframe linker's default), forcing a ~125 ms main-thread compile of the 6.8 MB payload and defeating both streaming compilation and Chromium's cross-launch code cache. `installCode=false` makes the linker use a script tag instead: the parse moves to a background thread and the code becomes cache-eligible (the cache also needs a stable origin across launches, a possible follow-up). Wall-clock neutral alone; groundwork for the rest.
- The boot sequence serialized Ace + style injection ahead of `client_init`, though neither is needed to send it; the main window now sends `client_init` first and loads Ace during the round trip, joining on Ace before building the workbench (~40 ms).
- `initializeWorkbench` no longer waits for the `set_user_state`/`set_user_prefs` round trips (~115 ms, queued behind the session's deferred init); the local pref refresh they perform synchronously is all the workbench needs.
- The vim/emacs keybinding bundles load lazily, requested by the first editor whose keybindings pref needs them; acesupport and ext-language-tools load in parallel after ace itself (a new `AsyncJavaScriptLoader` expresses staged parallel loads). Setup that must piggyback on the keybindings' arrival (vim ex commands, the emacs Return unbinding, the incremental-search message hook) re-runs on load, and everything that touched those modules unconditionally now tolerates their absence.
- Two bugs surfaced along the way: `RpcRequest` caught exceptions thrown by response *handlers* (not just JSON parsing) and misreported them as transmission errors, hiding real client bugs behind bogus retries -- the catch now covers only the parse; and `ConsolePane.getCharacterWidth()` could be called before the console shell exists once workbench init stopped blocking on the pref writes (it now reports 0, the documented "no valid measurement" value).

Open points for review:
- The static-asset fast path lives in `SessionHttpConnectionListenerImpl`, which all platforms use: Windows has constructed a `TcpIpHttpConnectionListener` (derived from it) since a7ffd1fd86 (2017), so it gets the fast path too. `SessionNamedPipeHttpConnectionListener.hpp` duplicates the enqueue logic without the fast path, but nothing has included it since that commit; it could be deleted in a separate cleanup.
- Static files are now always served from a dedicated session thread, for the life of the session, not just during startup. That seems like an improvement (deferred JS fragments load even while R is busy) but is a behavior change worth a look.
- A non-interactive `zsh -l -c` does not read `~/.zshrc`; that is pre-existing behavior of `SessionPath.cpp`, not changed here.

### Automated Tests

- Desktop unit tests for the timing writer, the login-shell PATH handoff (first launch waits, later launches use the remembered answer), and the Mach-O header reader; `npm test`, `npm run lint`, and `npm run typecheck` pass in `src/node/desktop`.
- The `tests/panes/editor` Playwright suite passes against the client-side wave (179 passed; the 13 failures are all `@ai` Copilot tests that need credentials not available locally), including the vimrc keybinding tests, which exercise the lazy vim path end-to-end.
- The Playwright desktop startup smoke test (`PW_RUN_SMOKE=1 npm run test:desktop-dev -- tests/smoke/startup.test.ts`) passes against the dev build, so the automation-agent launch path (no splash, pre-seeded cookies) still comes up.
- C++ (RelWithDebInfo) and full GWT builds are clean. The C++ unit test suite was not run locally.

### QA Notes

- On macOS, launch from the Dock or Finder (not a terminal) and compare `Sys.getenv("PATH")` with a new Terminal window; they should match on the second launch and after (the first launch after install still asks the shell before starting the session).
- Run `npm run startup-timing -- --runs=3` from the checkout to reproduce the timeline. Run 1 is a first launch; compare runs 2 and later.
- Start with a slow session (`RSTUDIO_SESSION_SLEEP_ON_STARTUP=10`): the loading page should appear immediately and the IDE should load when the session comes up, with no error page.
- Kill rsession during startup: the launch error page should still appear.


