### PR TITLE
Update Electron to 42.11.1

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "42.11.0",
+        "electron": "42.11.1",
         "electron-mocha": "13.1.0",
         "eslint": "10.8.1",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5911,9 +5911,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "42.11.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.11.0.tgz",
-      "integrity": "sha512-cVKNrRk+qedJspxeQm7HpPbALpPK8shfIBYAdqRbpw+4Gwn9+1HySne11ILs93Pmxt3z89wjso0AftadPd6Nqg==",
+      "version": "42.11.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.11.1.tgz",
+      "integrity": "sha512-mRYYjGDRWCyU+h4FU/0ruqxL/rXc+h2VCLhTb19KHu18HCUFWQAeFS/mFwnEKT/7GQCwlIHOhHie5ICLPXW6aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -57,7 +57,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "42.11.0",
+    "electron": "42.11.1",
     "electron-mocha": "13.1.0",
     "eslint": "10.8.1",
     "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -97,7 +97,7 @@
     "winston-syslog": "2.7.1"
   },
   "allowScripts": {
-    "electron@42.11.0": true,
+    "electron@42.11.1": true,
     "msgpackr-extract@3.0.3": true,
     "unix-dgram@2.0.6": true
   }

--- a/version/news/os/NEWS-2026.09.0-autumn-hawkbit.md
+++ b/version/news/os/NEWS-2026.09.0-autumn-hawkbit.md
@@ -52,7 +52,7 @@
 
 ### Dependencies
 - Copilot Language Server 1.531.0
-- Electron 42.11.0
+- Electron 42.11.1
 - Node.js 22.23.2 (GitHub Copilot, Posit Assistant)
 - Quarto 1.10.18
 


### PR DESCRIPTION
Updates the pinned Electron version from 42.11.0 to 42.11.1.

Chromium (148.0.7778.280), Node.js (24.19.0) and V8 (14.8.178.38) are all unchanged from 42.11.0 — this is a fix-only patch.

## Why take this update

**Security backports (electron/electron#53344).** Fifteen CVEs backported into the 42 branch without a Chromium version roll: CVE-2026-15764 through CVE-2026-15778.

**`contextBridge` and API-option crashes (electron/electron#53329).** Fixes a renderer crash when an array with a throwing property getter is passed across `contextBridge`, plus main- and utility-process crashes when option objects passed to Electron APIs contain throwing accessors or Proxy traps. RStudio exposes all of its renderer-facing APIs through `contextBridge` (`src/renderer/preload.ts`, `src/ui/widgets/choose-r/preload.ts`, `src/ui/whats-new/whats-new-preload.ts`), so this is the fix in the release that touches code paths we use. This is platform exposure rather than a traced failure — no RStudio call path was confirmed to crash.

## Not applicable to RStudio Desktop

- `chrome.tabs.query()` returning tab `url` and `title` to extensions without the `tabs` permission (electron/electron#53355) — RStudio loads no Chrome extensions; `src/node/desktop` has no `loadExtension` or extension-API usage.

## Testing

From `src/node/desktop`: `npm test` passes (456 passing), `npm run typecheck` passes, and `npm run lint` exits clean with 2 pre-existing warnings in `test/unit/main/session-launcher.test.ts` that this change does not touch. `node_modules/electron/dist/version` reports 42.11.1 — the binary is fetched lazily rather than by `npm install`, so it was pulled with `npx --no-install install-electron` and checked.

## Note on the target branch

This targets `rel-autumn-hawkbit` rather than `main`, so the dependency line was updated in `version/news/os/NEWS-2026.09.0-autumn-hawkbit.md` instead of a root `NEWS.md`.
