### PR TITLE
fix spurious diagnostics parse errors: indexed literals, hex literals, trailing semicolons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@
 -
 
 ### Fixed
+- ([#14363](https://github.com/rstudio/rstudio/issues/14363)): Fixed an issue where hexadecimal literals with binary exponents (e.g. `0x1p3`), fractions, uppercase `0X` prefixes, or an imaginary suffix were reported as parse errors
 - ([#18717](https://github.com/rstudio/rstudio/issues/18717)): Fixed an issue where the diagnostics system reported a spurious parse error for indexed numeric literals, e.g. `1[TRUE]`
+- ([#18722](https://github.com/rstudio/rstudio/issues/18722)): Fixed an issue where the diagnostics system reported "unexpected end of document" for R scripts ending with a semicolon
 
 ### Dependencies
 -

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 -
 
 ### Fixed
--
+- ([#18717](https://github.com/rstudio/rstudio/issues/18717)): Fixed an issue where the diagnostics system reported a spurious parse error for indexed numeric literals, e.g. `1[TRUE]`
 
 ### Dependencies
 -

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -55,7 +55,7 @@ private:
    friend TokenPatterns& tokenPatterns();
    TokenPatterns()
       : NUMBER(L"[0-9]*(\\.[0-9]*)?([eE][+-]?[0-9]*)?[Li]?"),
-        HEX_NUMBER(L"0x[0-9a-fA-F]*L?"),
+        HEX_NUMBER(L"0[xX][0-9a-fA-F]*(\\.[0-9a-fA-F]*)?([pP][+-]?[0-9]*)?[Li]?"),
         USER_OPERATOR(L"%[^\\n%]*%"),
         WHITESPACE(L"[\\s\x00A0\x3000]+"),
         COMMENT(L"#[^\\n]*$")

--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -148,6 +148,19 @@ void testNumbers()
    v.verify(L"2i");
    v.verify(L"4.1i");
    v.verify(L"1e-2i");
+
+   // hex literals: uppercase prefix, binary exponents,
+   // fractions, and suffixes (https://github.com/rstudio/rstudio/issues/14363)
+   v.verify(L"0XFF");
+   v.verify(L"0Xff");
+   v.verify(L"0x1p3");
+   v.verify(L"0xAp-2");
+   v.verify(L"0X2P2");
+   v.verify(L"0x1p-3");
+   v.verify(L"0x1.8p3");
+   v.verify(L"0x.8p2");
+   v.verify(L"0xFi");
+   v.verify(L"0xFL");
 }
 
 

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -312,6 +312,16 @@ TEST(DiagnosticsTest, ValidExpressionsGenerateNoLint) {
    EXPECT_NO_ERRORS("x[1, 2]");
    EXPECT_NO_ERRORS("x[, 1]");
    EXPECT_NO_ERRORS("x[1, ]");
+
+   // numeric literals can be indexed, and even 'called'
+   // https://github.com/rstudio/rstudio/issues/18717
+   EXPECT_NO_ERRORS("1[TRUE]");
+   EXPECT_NO_ERRORS("1[[1]]");
+   EXPECT_NO_ERRORS("quote(1[kg])");
+   EXPECT_NO_ERRORS("1.5e3[2]");
+   EXPECT_NO_ERRORS("0x10[[1]]");
+   EXPECT_NO_ERRORS("foo(1[2])");
+   EXPECT_NO_ERRORS("1(2)");
 }
 
 TEST(DiagnosticsTest, SymbolRangesDoNotLeakAcrossParseOperations) {

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -322,6 +322,24 @@ TEST(DiagnosticsTest, ValidExpressionsGenerateNoLint) {
    EXPECT_NO_ERRORS("0x10[[1]]");
    EXPECT_NO_ERRORS("foo(1[2])");
    EXPECT_NO_ERRORS("1(2)");
+
+   // hex literals with uppercase prefixes, binary exponents, fractions
+   // https://github.com/rstudio/rstudio/issues/14363
+   EXPECT_NO_ERRORS("0XFF");
+   EXPECT_NO_ERRORS("x <- 0x1p3");
+   EXPECT_NO_ERRORS("0xAp-2 + 0X2P2");
+   EXPECT_NO_ERRORS("0x1.8p3");
+   EXPECT_NO_ERRORS("0xFi");
+   EXPECT_NO_ERRORS("0xFL");
+
+   // semicolons can end the document
+   EXPECT_NO_ERRORS("1;");
+   EXPECT_NO_ERRORS("x <- 1;");
+   EXPECT_NO_ERRORS("f(); g();");
+   EXPECT_NO_ERRORS("1; ");
+   EXPECT_NO_ERRORS("1;\n");
+   EXPECT_NO_ERRORS("f <- function() 1;");
+   EXPECT_ERRORS("1;;");
 }
 
 TEST(DiagnosticsTest, SymbolRangesDoNotLeakAcrossParseOperations) {

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -3001,22 +3001,39 @@ START:
          if (status.isInParentheticalScope())
             GOTO_INVALID_TOKEN(cursor);
          
+         // A semicolon can validly end the document, so plain cursor
+         // moves (ending the parse at end of document) are used below,
+         // rather than the macros which would lint the end of document.
+         //
          // Ensure that we don't have excess semi-colons following.
-         MOVE_TO_NEXT_TOKEN(cursor, status);
+         if (!cursor.moveToNextToken())
+            return;
+
          if (isBlank(cursor))
-            MOVE_TO_NEXT_TOKEN(cursor, status);
-         
+         {
+            if (!cursor.moveToNextToken())
+               return;
+         }
+
          while (cursor.isType(RToken::SEMI))
          {
             status.lint().unexpectedToken(cursor);
-            MOVE_TO_NEXT_TOKEN(cursor, status);
+            if (!cursor.moveToNextToken())
+               return;
+
             if (isBlank(cursor))
-               MOVE_TO_NEXT_TOKEN(cursor, status);
+            {
+               if (!cursor.moveToNextToken())
+                  return;
+            }
          }
-         
+
          if (isWhitespace(cursor))
-            MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
-         
+         {
+            if (!cursor.moveToNextSignificantToken())
+               return;
+         }
+
          goto START;
       }
       

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -3086,7 +3086,6 @@ START:
          }
          
          // Move to the next token.
-         bool isNumber = cursor.isType(RToken::NUMBER);
          const RToken& next = cursor.nextSignificantToken();
          
          // If we encounter an operator, we need to figure out whether it's
@@ -3122,9 +3121,10 @@ START:
             }
          }
          
-         // Identifiers followed by brackets are function calls.
-         // Only non-numeric symbols can be function calls.
-         if (!isNumber && canOpenArgumentList(next))
+         // An expression followed by an opening bracket is a function
+         // call or an indexing operation. Note that this is legal even
+         // for numeric literals, e.g. '1[TRUE]' is valid R code.
+         if (canOpenArgumentList(next))
          {
             MOVE_TO_NEXT_SIGNIFICANT_TOKEN_WARN_ON_BLANK(cursor, status);
             goto ARGUMENT_LIST;

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -359,7 +359,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
     rules["#number"] = [
       {
         token : "constant.numeric", // hex
-        regex : "0[xX][0-9a-fA-F]+[Li]?",
+        regex : "0[xX][0-9a-fA-F]*(?:\\.[0-9a-fA-F]*)?(?:[pP][+-]?\\d*)?[Li]?",
         merge : false,
         next  : "start"
       },

--- a/src/gwt/src/org/rstudio/studio/client/common/r/RTokenizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/r/RTokenizer.java
@@ -155,7 +155,7 @@ public class RTokenizer
    
    private RToken matchNumber()
    {
-      String num = peek("0x[0-9a-fA-F]*L?");
+      String num = peek("0[xX][0-9a-fA-F]*(\\.[0-9a-fA-F]*)?([pP][+-]?[0-9]*)?[Li]?");
       if (num == null)
          num = peek("[0-9]*(\\.[0-9]*)?([eE][+-]?[0-9]*)?[Li]?");
 

--- a/src/gwt/test/org/rstudio/studio/client/common/r/RTokenizerTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/common/r/RTokenizerTests.java
@@ -66,8 +66,14 @@ public class RTokenizerTests extends GWTTestCase
       v.verify(new String[] {
             "1", "10", "0.1", ".2", "1e-7", "1.2e+7", "2e", "3e+",
             "0x", "0x0", "0xDEADBEEF", "0xcafebad", "1L", "0x10L",
-            "1000000L", "1e6L", "1.1L", "1e-3L", "2i", "4.1i", 
-            "1e-2i"
+            "1000000L", "1e6L", "1.1L", "1e-3L", "2i", "4.1i",
+            "1e-2i",
+
+            // hex literals: uppercase prefix, binary exponents,
+            // fractions, and suffixes
+            // https://github.com/rstudio/rstudio/issues/14363
+            "0XFF", "0Xff", "0x1p3", "0xAp-2", "0X2P2", "0x1p-3",
+            "0x1.8p3", "0x.8p2", "0xFi", "0xFL"
       });
    }
    


### PR DESCRIPTION
Differential testing of the diagnostics R parser against R's own parser surfaced a family of false positives, fixed here:

1. **Indexed / called numeric literals.** The parser rejected a numeric literal followed by `(`, `[`, or `[[`, reporting "unexpected token '['" for valid code such as `1[TRUE]` or `quote(1[kg])`. Per the R grammar, any expression -- including a constant -- can be followed by a call or indexing bracket, so the special case excluding numbers is dropped.

2. **Hex literals.** The tokenizers (C++ `RTokenizer`, the Java `RTokenizer`, and the Ace highlight rules) recognized only the `0x[0-9a-fA-F]*L?` form, so valid literals with an uppercase `0X` prefix (`0XFF`), a binary exponent (`0x1p3`, `0xAp-2`), a fraction (`0x1.8p3`), or an imaginary suffix (`0xFi`) were reported as parse errors (and mis-highlighted in the editor). The patterns now follow `?NumericConstants`.

3. **Trailing semicolons.** A semicolon ending the final statement of a script (e.g. a file containing `x <- 1;`) was reported as "unexpected end of document", although a semicolon can validly end a document. The semicolon handler now ends the parse quietly at end of document; unclosed brackets are still reported via the bracket stack check.

Regression tests added to `SessionDiagnosticsTests.cpp`, `RTokenizerTests.cpp`, and `RTokenizerTests.java`. Verified locally: `core` and `rsession` test scopes, GWT `ant unittest` (581 tests) and `ant testpage` (677 checks), plus a differential harness of ~120 expressions comparing `parse()` and `.rs.lintRFile()` verdicts, which now reports zero false positives.

Fixes #18717.
Fixes #14363.
Fixes #18722.