### PR TITLE
reduce installed package size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## RStudio 2026.10.0 "Blue Mistflower" Release Notes
 
 ### New
+- Reduced the disk space used by RStudio installations: Copilot Language Server binaries for other platforms are no longer installed, JavaScript source maps are no longer packaged, GWT symbol maps are stored compressed, and macOS application bundles are now transparently compressed on disk.
 -
 
 ### Fixed

--- a/cmake/gzip-file.cmake
+++ b/cmake/gzip-file.cmake
@@ -31,3 +31,8 @@ file(ARCHIVE_CREATE
    PATHS "${INPUT}"
    FORMAT raw
    COMPRESSION GZip)
+
+# match the permissions install(DIRECTORY) applies to installed files,
+# rather than inheriting the caller's umask
+file(CHMOD "${OUTPUT}"
+   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)

--- a/cmake/gzip-file.cmake
+++ b/cmake/gzip-file.cmake
@@ -1,0 +1,33 @@
+#
+# gzip-file.cmake
+#
+# Copyright (C) 2026 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+# Compresses INPUT into OUTPUT as a raw gzip stream. Run this script with the
+# working directory set to INPUT's folder and INPUT as a bare file name:
+# file(ARCHIVE_CREATE) resolves its input paths relative to the current
+# working directory, which breaks when the caller's working directory has
+# symlinked components (e.g. /tmp on macOS).
+#
+# Usage:
+#   cmake -DINPUT=<file name> -DOUTPUT=<absolute path> -P gzip-file.cmake
+
+if(NOT INPUT OR NOT OUTPUT)
+   message(FATAL_ERROR "gzip-file.cmake requires -DINPUT=<file> and -DOUTPUT=<file>")
+endif()
+
+file(ARCHIVE_CREATE
+   OUTPUT "${OUTPUT}"
+   PATHS "${INPUT}"
+   FORMAT raw
+   COMPRESSION GZip)

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -471,6 +471,25 @@ if [ "${build_package}" = "1" ]; then
       # move to target directory
       cd "${INSTALL_DIR}"
 
+      # transparently compress the application bundle on disk (APFS / HFS+
+      # decmpfs). The compression is preserved when the bundle is copied into
+      # the DMG and when users drag-install from it, roughly halving the
+      # installed size; copies made with tools that do not preserve the
+      # attribute silently fall back to the full size. Code signatures remain
+      # valid because they cover the (unchanged) logical file contents. This
+      # step must run after signing, since signing rewrites the files and
+      # would discard the compression.
+      for app in *.app; do
+         info "Compressing '${app}' ..."
+         rm -rf "${app}.compressed"
+         ditto --hfsCompression "${app}" "${app}.compressed"
+         rm -rf "${app}"
+         mv "${app}.compressed" "${app}"
+         info "Verifying code signature of '${app}' ..."
+         codesign --verify --strict "${app}"
+         info "Done!"
+      done
+
       # create 'Applications' symlink
       ln -nfs /Applications Applications
 

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -486,7 +486,7 @@ if [ "${build_package}" = "1" ]; then
          rm -rf "${app}"
          mv "${app}.compressed" "${app}"
          info "Verifying code signature of '${app}' ..."
-         codesign --verify --strict "${app}"
+         codesign --verify --deep --strict "${app}"
          info "Done!"
       done
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -88,10 +88,6 @@ if(UNIX)
       find_library(SECURITY_LIBRARY NAMES Security)
    endif()
 
-   # workaround boost bug (https://svn.boost.org/trac/boost/ticket/4568)
-   # by disabling kqueue support. note that this bug was fixed in boost 1.45
-   add_definitions(-DBOOST_ASIO_DISABLE_KQUEUE)
-
    if(APPLE)
 
       # Figure out what version of Mac OS X this is. Unfortunately

--- a/src/cpp/core/ZlibUtil.cpp
+++ b/src/cpp/core/ZlibUtil.cpp
@@ -16,6 +16,8 @@
 #include <core/ZlibUtil.hpp>
 
 #include <cstring> // for memcpy
+#include <istream>
+#include <stdexcept>
 
 #include <core/Log.hpp>
 
@@ -264,6 +266,115 @@ Error decompressString(const std::vector<unsigned char>& compressedData,
 
    *str = destBuff.toString();
    return Success();
+}
+
+struct GzipDecompressingStreambuf::Impl
+{
+   explicit Impl(std::istream& source)
+      : source(source),
+        sourceEof(false),
+        memberComplete(false),
+        finished(false)
+   {
+      std::memset(&stream, 0, sizeof(stream));
+   }
+
+   std::istream& source;
+   z_stream stream;
+   bool sourceEof;
+   bool memberComplete;
+   bool finished;
+   char input[8192];
+   char output[8192];
+};
+
+GzipDecompressingStreambuf::GzipDecompressingStreambuf(std::istream& source)
+   : pImpl_(new Impl(source))
+{
+   // 15 is the maximum window size; adding 16 selects gzip framing (zlib
+   // then also verifies each member's trailer CRC on decompression)
+   int result = inflateInit2(&pImpl_->stream, 15 + 16);
+   if (result != Z_OK)
+      throw std::runtime_error(std::string("zlib initialization failed: ") + zError(result));
+}
+
+GzipDecompressingStreambuf::~GzipDecompressingStreambuf()
+{
+   inflateEnd(&pImpl_->stream);
+}
+
+GzipDecompressingStreambuf::int_type GzipDecompressingStreambuf::underflow()
+{
+   if (gptr() < egptr())
+      return traits_type::to_int_type(*gptr());
+
+   if (pImpl_->finished)
+      return traits_type::eof();
+
+   z_stream& stream = pImpl_->stream;
+
+   for (;;)
+   {
+      // refill the input buffer when it is empty
+      if (stream.avail_in == 0 && !pImpl_->sourceEof)
+      {
+         pImpl_->source.read(pImpl_->input, sizeof(pImpl_->input));
+         if (pImpl_->source.bad())
+            throw std::runtime_error("error reading compressed stream");
+
+         if (pImpl_->source.eof())
+            pImpl_->sourceEof = true;
+
+         stream.next_in = reinterpret_cast<Bytef*>(pImpl_->input);
+         stream.avail_in = static_cast<uInt>(pImpl_->source.gcount());
+      }
+
+      // at a member boundary, either finish (nothing follows) or expect
+      // another concatenated gzip member
+      if (pImpl_->memberComplete)
+      {
+         if (stream.avail_in == 0 && pImpl_->sourceEof)
+         {
+            pImpl_->finished = true;
+            return traits_type::eof();
+         }
+
+         int result = inflateReset(&stream);
+         if (result != Z_OK)
+            throw std::runtime_error(std::string("zlib reset failed: ") + zError(result));
+
+         pImpl_->memberComplete = false;
+      }
+
+      stream.next_out = reinterpret_cast<Bytef*>(pImpl_->output);
+      stream.avail_out = sizeof(pImpl_->output);
+
+      int result = inflate(&stream, Z_NO_FLUSH);
+      std::size_t produced = sizeof(pImpl_->output) - stream.avail_out;
+
+      if (result == Z_STREAM_END)
+      {
+         pImpl_->memberComplete = true;
+      }
+      else if (result == Z_BUF_ERROR)
+      {
+         // inflate could make no progress: recoverable by supplying more
+         // input, so with the source exhausted the stream is truncated
+         if (stream.avail_in == 0 && pImpl_->sourceEof)
+            throw std::runtime_error("gzip stream is truncated");
+      }
+      else if (result != Z_OK)
+      {
+         const char* msg = (stream.msg != nullptr) ? stream.msg : zError(result);
+         throw std::runtime_error(std::string("gzip decompression failed: ") + msg);
+      }
+
+      if (produced > 0)
+      {
+         setg(pImpl_->output, pImpl_->output, pImpl_->output + produced);
+         return traits_type::to_int_type(*gptr());
+      }
+   }
 }
 
 } // namespace zlib

--- a/src/cpp/core/ZlibUtil.cpp
+++ b/src/cpp/core/ZlibUtil.cpp
@@ -266,54 +266,6 @@ Error decompressString(const std::vector<unsigned char>& compressedData,
    return Success();
 }
 
-Error decompressGzip(const std::vector<unsigned char>& compressedData,
-                     std::string* str)
-{
-   if (compressedData.empty())
-   {
-      *str = "";
-      return Success();
-   }
-
-   size_t dataLen = compressedData.size();
-   ByteBuffer srcBuff(dataLen);
-   srcBuff.append(compressedData.data(), dataLen);
-
-   ByteBuffer destBuff(dataLen * 2);
-
-   z_stream zStream;
-   size_t remainIn, remainOut;
-   makeZStream(srcBuff, destBuff, &remainIn, &remainOut, &zStream);
-
-   // windowBits of MAX_WBITS + 16 requests decoding of the gzip format
-   int res = inflateInit2(&zStream, MAX_WBITS + 16);
-   if (res != Z_OK)
-      return systemError(res, "ZLib initialization error", ERROR_LOCATION);
-
-   while (res != Z_STREAM_END)
-   {
-      updateOut(&destBuff, &remainOut, &zStream);
-
-      res = inflate(&zStream, Z_NO_FLUSH);
-      destBuff.setDataSize(zStream.total_out);
-      if ((res == Z_DATA_ERROR) || (res == Z_NEED_DICT) || (res == Z_MEM_ERROR) ||
-          (res == Z_BUF_ERROR && zStream.avail_in == 0 && remainIn == 0))
-      {
-         inflateEnd(&zStream);
-         return systemError(res, "ZLib inflation error", ERROR_LOCATION);
-      }
-
-      updateIn(&srcBuff, &remainIn, &zStream);
-   }
-
-   inflateEnd(&zStream);
-
-   // unlike decompressString(), the decompressed data carries no trailing
-   // NUL, so the string must be built with an explicit length
-   str->assign(reinterpret_cast<const char*>(destBuff.get()), destBuff.dataSize());
-   return Success();
-}
-
 } // namespace zlib
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/ZlibUtil.cpp
+++ b/src/cpp/core/ZlibUtil.cpp
@@ -266,6 +266,54 @@ Error decompressString(const std::vector<unsigned char>& compressedData,
    return Success();
 }
 
+Error decompressGzip(const std::vector<unsigned char>& compressedData,
+                     std::string* str)
+{
+   if (compressedData.empty())
+   {
+      *str = "";
+      return Success();
+   }
+
+   size_t dataLen = compressedData.size();
+   ByteBuffer srcBuff(dataLen);
+   srcBuff.append(compressedData.data(), dataLen);
+
+   ByteBuffer destBuff(dataLen * 2);
+
+   z_stream zStream;
+   size_t remainIn, remainOut;
+   makeZStream(srcBuff, destBuff, &remainIn, &remainOut, &zStream);
+
+   // windowBits of MAX_WBITS + 16 requests decoding of the gzip format
+   int res = inflateInit2(&zStream, MAX_WBITS + 16);
+   if (res != Z_OK)
+      return systemError(res, "ZLib initialization error", ERROR_LOCATION);
+
+   while (res != Z_STREAM_END)
+   {
+      updateOut(&destBuff, &remainOut, &zStream);
+
+      res = inflate(&zStream, Z_NO_FLUSH);
+      destBuff.setDataSize(zStream.total_out);
+      if ((res == Z_DATA_ERROR) || (res == Z_NEED_DICT) || (res == Z_MEM_ERROR) ||
+          (res == Z_BUF_ERROR && zStream.avail_in == 0 && remainIn == 0))
+      {
+         inflateEnd(&zStream);
+         return systemError(res, "ZLib inflation error", ERROR_LOCATION);
+      }
+
+      updateIn(&srcBuff, &remainIn, &zStream);
+   }
+
+   inflateEnd(&zStream);
+
+   // unlike decompressString(), the decompressed data carries no trailing
+   // NUL, so the string must be built with an explicit length
+   str->assign(reinterpret_cast<const char*>(destBuff.get()), destBuff.dataSize());
+   return Success();
+}
+
 } // namespace zlib
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/ZlibUtilTests.cpp
+++ b/src/cpp/core/ZlibUtilTests.cpp
@@ -19,10 +19,43 @@
 
 #include <algorithm>
 #include <iterator>
+#include <sstream>
 
 namespace rstudio {
 namespace core {
 namespace zlib {
+
+namespace {
+
+const std::string kGzipFixtureContents = "The quick brown fox jumps over the lazy dog.\n";
+
+// 'gzip -n' output for kGzipFixtureContents
+const unsigned char kGzipFixture[] = {
+   31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 11, 201, 72, 85, 40, 44,
+   205, 76, 206, 86, 72, 42, 202, 47, 207, 83, 72, 203, 175, 80, 200, 42,
+   205, 45, 40, 86, 200, 47, 75, 45, 82, 40, 1, 74, 231, 36, 86, 85,
+   42, 164, 228, 167, 235, 113, 1, 0, 106, 204, 80, 235, 45, 0, 0, 0
+};
+
+std::string gzipFixture(std::size_t length)
+{
+   return std::string(reinterpret_cast<const char*>(kGzipFixture), length);
+}
+
+std::string readAll(std::istream& is)
+{
+   char buffer[64];
+   std::string contents;
+   while (is.read(buffer, sizeof(buffer)))
+   {
+      contents.append(buffer, static_cast<std::size_t>(is.gcount()));
+   }
+   contents.append(buffer, static_cast<std::size_t>(is.gcount()));
+
+   return contents;
+}
+
+} // anonymous namespace
 
 TEST(ZlibTest, CanCompressAndDecompressDifficultStrings)
 {
@@ -94,6 +127,68 @@ TEST(ZlibTest, InvalidCompressedStringFailsToDecompress)
    std::string uncompressed;
    Error error = decompressString(compressed, &uncompressed);
    ASSERT_TRUE(error);
+}
+
+TEST(ZlibTest, GzipStreambufDecompressesGzipStream)
+{
+   std::istringstream source(gzipFixture(sizeof(kGzipFixture)));
+   GzipDecompressingStreambuf streambuf(source);
+   std::istream is(&streambuf);
+
+   std::string contents = readAll(is);
+
+   EXPECT_FALSE(is.bad());
+   EXPECT_EQ(kGzipFixtureContents, contents);
+}
+
+TEST(ZlibTest, GzipStreambufDecompressesConcatenatedMembers)
+{
+   // a gzip stream is a sequence of members; all of them are decompressed
+   std::string twoMembers = gzipFixture(sizeof(kGzipFixture)) + gzipFixture(sizeof(kGzipFixture));
+   std::istringstream source(twoMembers);
+   GzipDecompressingStreambuf streambuf(source);
+   std::istream is(&streambuf);
+
+   std::string contents = readAll(is);
+
+   EXPECT_FALSE(is.bad());
+   EXPECT_EQ(kGzipFixtureContents + kGzipFixtureContents, contents);
+}
+
+TEST(ZlibTest, GzipStreambufSetsBadbitOnCorruptStream)
+{
+   std::istringstream source("not gzip data");
+   GzipDecompressingStreambuf streambuf(source);
+   std::istream is(&streambuf);
+
+   readAll(is);
+
+   EXPECT_TRUE(is.bad());
+}
+
+TEST(ZlibTest, GzipStreambufSetsBadbitOnTruncatedStream)
+{
+   // cut mid-deflate, before the trailer
+   std::istringstream source(gzipFixture(sizeof(kGzipFixture) - 20));
+   GzipDecompressingStreambuf streambuf(source);
+   std::istream is(&streambuf);
+
+   readAll(is);
+
+   EXPECT_TRUE(is.bad());
+}
+
+TEST(ZlibTest, GzipStreambufSetsBadbitOnMissingTrailer)
+{
+   // the deflate data is intact, but the 8-byte trailer (CRC + size) is
+   // missing: the content decodes, but the stream must still fail
+   std::istringstream source(gzipFixture(sizeof(kGzipFixture) - 8));
+   GzipDecompressingStreambuf streambuf(source);
+   std::istream is(&streambuf);
+
+   readAll(is);
+
+   EXPECT_TRUE(is.bad());
 }
 
 } // namespace zlib

--- a/src/cpp/core/ZlibUtilTests.cpp
+++ b/src/cpp/core/ZlibUtilTests.cpp
@@ -96,6 +96,50 @@ TEST(ZlibTest, InvalidCompressedStringFailsToDecompress)
    ASSERT_TRUE(error);
 }
 
+TEST(ZlibTest, CanDecompressGzipFormat)
+{
+   // 'gzip -n' output for "The quick brown fox jumps over the lazy dog."
+   const unsigned char gzipData[] = {
+      31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 11, 201, 72, 85, 40, 44,
+      205, 76, 206, 86, 72, 42, 202, 47, 207, 83, 72, 203, 175, 80, 200, 42,
+      205, 45, 40, 86, 200, 47, 75, 45, 82, 40, 1, 74, 231, 36, 86, 85,
+      42, 164, 228, 167, 235, 1, 0, 233, 37, 144, 81, 44, 0, 0, 0
+   };
+
+   std::vector<unsigned char> compressed(gzipData, gzipData + sizeof(gzipData));
+
+   std::string uncompressed;
+   Error error = decompressGzip(compressed, &uncompressed);
+   ASSERT_FALSE(error);
+
+   EXPECT_EQ("The quick brown fox jumps over the lazy dog.", uncompressed);
+}
+
+TEST(ZlibTest, DecompressGzipRejectsZlibFormat)
+{
+   const std::string original = "The quick brown fox jumps over the lazy dog.";
+
+   std::vector<unsigned char> compressed;
+   Error error = compressString(original, &compressed);
+   ASSERT_FALSE(error);
+
+   std::string uncompressed;
+   error = decompressGzip(compressed, &uncompressed);
+   ASSERT_TRUE(error);
+}
+
+TEST(ZlibTest, InvalidGzipDataFailsToDecompress)
+{
+   const std::string invalidCompressed = "not gzip data";
+
+   std::vector<unsigned char> compressed;
+   std::copy(invalidCompressed.begin(), invalidCompressed.end(), std::back_inserter(compressed));
+
+   std::string uncompressed;
+   Error error = decompressGzip(compressed, &uncompressed);
+   ASSERT_TRUE(error);
+}
+
 } // namespace zlib
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/ZlibUtilTests.cpp
+++ b/src/cpp/core/ZlibUtilTests.cpp
@@ -96,50 +96,6 @@ TEST(ZlibTest, InvalidCompressedStringFailsToDecompress)
    ASSERT_TRUE(error);
 }
 
-TEST(ZlibTest, CanDecompressGzipFormat)
-{
-   // 'gzip -n' output for "The quick brown fox jumps over the lazy dog."
-   const unsigned char gzipData[] = {
-      31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 11, 201, 72, 85, 40, 44,
-      205, 76, 206, 86, 72, 42, 202, 47, 207, 83, 72, 203, 175, 80, 200, 42,
-      205, 45, 40, 86, 200, 47, 75, 45, 82, 40, 1, 74, 231, 36, 86, 85,
-      42, 164, 228, 167, 235, 1, 0, 233, 37, 144, 81, 44, 0, 0, 0
-   };
-
-   std::vector<unsigned char> compressed(gzipData, gzipData + sizeof(gzipData));
-
-   std::string uncompressed;
-   Error error = decompressGzip(compressed, &uncompressed);
-   ASSERT_FALSE(error);
-
-   EXPECT_EQ("The quick brown fox jumps over the lazy dog.", uncompressed);
-}
-
-TEST(ZlibTest, DecompressGzipRejectsZlibFormat)
-{
-   const std::string original = "The quick brown fox jumps over the lazy dog.";
-
-   std::vector<unsigned char> compressed;
-   Error error = compressString(original, &compressed);
-   ASSERT_FALSE(error);
-
-   std::string uncompressed;
-   error = decompressGzip(compressed, &uncompressed);
-   ASSERT_TRUE(error);
-}
-
-TEST(ZlibTest, InvalidGzipDataFailsToDecompress)
-{
-   const std::string invalidCompressed = "not gzip data";
-
-   std::vector<unsigned char> compressed;
-   std::copy(invalidCompressed.begin(), invalidCompressed.end(), std::back_inserter(compressed));
-
-   std::string uncompressed;
-   Error error = decompressGzip(compressed, &uncompressed);
-   ASSERT_TRUE(error);
-}
-
 } // namespace zlib
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -18,6 +18,8 @@
 #include <string>
 #include <map>
 #include <set>
+#include <sstream>
+#include <iterator>
 #include <algorithm>
 
 #include <boost/regex.hpp>
@@ -29,6 +31,7 @@
 #include <core/RegexUtils.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/ZlibUtil.hpp>
 
 using namespace boost::placeholders;
 
@@ -72,6 +75,36 @@ ReadCollectionAction parseSymbolMapLine(
    pSymbolsLeftToFind->erase(*pFirst);
 
    return ReadCollectionAddLine;
+}
+
+Error readGzippedSymbolMap(const FilePath& gzMapPath,
+                           std::map<std::string,std::string>* pMap,
+                           std::set<std::string>* pSymbolsLeftToFind)
+{
+   // read the compressed contents
+   std::shared_ptr<std::istream> pIfs;
+   Error error = gzMapPath.openForRead(pIfs);
+   if (error)
+      return error;
+
+   std::vector<unsigned char> compressedData(
+            (std::istreambuf_iterator<char>(*pIfs)),
+            std::istreambuf_iterator<char>());
+
+   // decompress, then parse lines as for the plain symbol map
+   std::string contents;
+   error = zlib::decompressGzip(compressedData, &contents);
+   if (error)
+   {
+      error.addProperty("path", gzMapPath.getAbsolutePath());
+      return error;
+   }
+
+   std::istringstream is(contents);
+   return readCollectionFromStream<std::map<std::string,std::string> >(
+            is,
+            pMap,
+            boost::bind(parseSymbolMapLine, _1, _2, pSymbolsLeftToFind));
 }
 
 class SymbolCache : boost::noncopyable
@@ -159,8 +192,11 @@ struct SymbolMaps::Impl
       // lookup additional symbols by reading the file
       std::set<std::string> symbolsLeftToFind = requiredSymbols;
 
-      // read it from disk if it exists
+      // read it from disk if it exists; packaged builds ship the symbol map
+      // gzipped, so fall back to the compressed form when the plain file is
+      // not available
       FilePath mapPath = symbolMapsPath.completeChildPath(strongName + ".symbolMap");
+      FilePath gzMapPath = symbolMapsPath.completeChildPath(strongName + ".symbolMap.gz");
       if (mapPath.exists())
       {
          Error error = readCollectionFromFile
@@ -171,6 +207,14 @@ struct SymbolMaps::Impl
          if (error)
             LOG_ERROR(error);
 
+      }
+      else if (gzMapPath.exists())
+      {
+         Error error = readGzippedSymbolMap(gzMapPath,
+                                            &toReturn,
+                                            &symbolsLeftToFind);
+         if (error)
+            LOG_ERROR(error);
       }
 
       // mark all remaining symbols as having been looked for

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -202,33 +202,35 @@ struct SymbolMaps::Impl
    FilePath symbolMapsPath;
    SymbolCache symbolCache;
    boost::mutex validationMutex;
-   std::map<std::string,bool> gzMapValidation;
+   std::set<std::string> validatedGzMaps;
 
-   // validate each gzipped symbol map's integrity once; reads after
-   // validation terminate early and skip the trailer CRC (see
+   // validate each gzipped symbol map's integrity before allowing
+   // early-terminating reads, which skip the trailer CRC (see
    // readGzippedSymbolMap)
    //
-   // NOTE: results are memoized by path for the process lifetime. symbol
-   // maps are content-addressed (the file name is the GWT permutation's
-   // strong name), so the contents under a given path never change; and the
-   // symbol cache already memoizes failed lookups permanently, so
-   // revalidating would not restore symbols that a failure already poisoned
+   // successful validations are memoized by path for the process lifetime;
+   // this assumes the file's contents are stable, which holds in practice
+   // because the file name is the GWT permutation's strong name (a content
+   // hash). failures are deliberately not memoized, so a file that was
+   // unreadable or damaged is revalidated on the next lookup and recovers
+   // if it has been repaired or replaced.
    bool validateGzippedSymbolMap(const FilePath& gzMapPath)
    {
       LOCK_MUTEX(validationMutex)
       {
          std::string path = gzMapPath.getAbsolutePath();
-         std::map<std::string,bool>::const_iterator it = gzMapValidation.find(path);
-         if (it != gzMapValidation.end())
-            return it->second;
+         if (validatedGzMaps.count(path) != 0)
+            return true;
 
          Error error = validateGzipFile(gzMapPath);
          if (error)
+         {
             LOG_ERROR(error);
+            return false;
+         }
 
-         bool valid = !error;
-         gzMapValidation[path] = valid;
-         return valid;
+         validatedGzMaps.insert(path);
+         return true;
       }
       END_LOCK_MUTEX
 

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -89,6 +89,12 @@ Error readGzippedSymbolMap(const FilePath& gzMapPath,
    // terminate early without inflating the whole file (as with the plain
    // symbol map). decompression errors surface as stream failures, which
    // readCollectionFromStream() reports.
+   //
+   // NOTE: terminating early means the gzip trailer CRC is not validated
+   // for the unread remainder of the file. that is deliberate: symbol maps
+   // are best-effort diagnostics (the plain-file path performs no integrity
+   // validation at all), and corruption within the consumed region still
+   // surfaces as an inflate failure.
    boost::iostreams::filtering_istream is;
    is.push(boost::iostreams::gzip_decompressor());
    is.push(*pIfs);

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -285,8 +285,11 @@ struct SymbolMaps::Impl
       {
          if (validateGzippedSymbolMap(gzMapPath))
          {
+            // parse into a scratch map that is merged only on success, so
+            // that a read failing partway through contributes nothing
+            std::map<std::string,std::string> gzSymbols;
             Error error = readGzippedSymbolMap(gzMapPath,
-                                               &toReturn,
+                                               &gzSymbols,
                                                &symbolsLeftToFind);
             if (error)
             {
@@ -295,6 +298,10 @@ struct SymbolMaps::Impl
                // treat a failed read like a failed validation below: leave
                // the symbols uncached so a later lookup can retry them
                cacheMissingSymbols = false;
+            }
+            else
+            {
+               toReturn.insert(gzSymbols.begin(), gzSymbols.end());
             }
          }
          else

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -19,16 +19,16 @@
 #include <map>
 #include <set>
 #include <algorithm>
+#include <istream>
 
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/bind/bind.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
-#include <boost/iostreams/filter/gzip.hpp>
 
 #include <core/Thread.hpp>
 #include <core/RegexUtils.hpp>
+#include <core/ZlibUtil.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <core/FileSerializer.hpp>
 
@@ -92,14 +92,22 @@ Error readGzippedSymbolMap(const FilePath& gzMapPath,
    // validateGzipFile); corruption within the consumed region still
    // surfaces as an inflate failure, which readCollectionFromStream()
    // reports as a stream error.
-   boost::iostreams::filtering_istream is;
-   is.push(boost::iostreams::gzip_decompressor());
-   is.push(*pIfs);
+   try
+   {
+      zlib::GzipDecompressingStreambuf streambuf(*pIfs);
+      std::istream is(&streambuf);
 
-   error = readCollectionFromStream<std::map<std::string,std::string> >(
-            is,
-            pMap,
-            boost::bind(parseSymbolMapLine, _1, _2, pSymbolsLeftToFind));
+      error = readCollectionFromStream<std::map<std::string,std::string> >(
+               is,
+               pMap,
+               boost::bind(parseSymbolMapLine, _1, _2, pSymbolsLeftToFind));
+   }
+   catch(const std::exception& e)
+   {
+      error = systemError(boost::system::errc::io_error, ERROR_LOCATION);
+      error.addProperty("what", e.what());
+   }
+
    if (error)
       error.addProperty("path", gzMapPath.getAbsolutePath());
 
@@ -118,9 +126,8 @@ Error validateGzipFile(const FilePath& gzPath)
    // (including a truncated trailer) set the stream's badbit.
    try
    {
-      boost::iostreams::filtering_istream is;
-      is.push(boost::iostreams::gzip_decompressor());
-      is.push(*pIfs);
+      zlib::GzipDecompressingStreambuf streambuf(*pIfs);
+      std::istream is(&streambuf);
 
       char buffer[8192];
       while (is.read(buffer, sizeof(buffer)))

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -207,6 +207,12 @@ struct SymbolMaps::Impl
    // validate each gzipped symbol map's integrity once; reads after
    // validation terminate early and skip the trailer CRC (see
    // readGzippedSymbolMap)
+   //
+   // NOTE: results are memoized by path for the process lifetime. symbol
+   // maps are content-addressed (the file name is the GWT permutation's
+   // strong name), so the contents under a given path never change; and the
+   // symbol cache already memoizes failed lookups permanently, so
+   // revalidating would not restore symbols that a failure already poisoned
    bool validateGzippedSymbolMap(const FilePath& gzMapPath)
    {
       LOCK_MUTEX(validationMutex)

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -289,7 +289,13 @@ struct SymbolMaps::Impl
                                                &toReturn,
                                                &symbolsLeftToFind);
             if (error)
+            {
                LOG_ERROR(error);
+
+               // treat a failed read like a failed validation below: leave
+               // the symbols uncached so a later lookup can retry them
+               cacheMissingSymbols = false;
+            }
          }
          else
          {

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -87,14 +87,11 @@ Error readGzippedSymbolMap(const FilePath& gzMapPath,
 
    // stream the decompression through the line parser, so that lookups can
    // terminate early without inflating the whole file (as with the plain
-   // symbol map). decompression errors surface as stream failures, which
-   // readCollectionFromStream() reports.
-   //
-   // NOTE: terminating early means the gzip trailer CRC is not validated
-   // for the unread remainder of the file. that is deliberate: symbol maps
-   // are best-effort diagnostics (the plain-file path performs no integrity
-   // validation at all), and corruption within the consumed region still
-   // surfaces as an inflate failure.
+   // symbol map). terminating early skips the gzip trailer CRC for the
+   // unread remainder, so callers validate the payload once up front (see
+   // validateGzipFile); corruption within the consumed region still
+   // surfaces as an inflate failure, which readCollectionFromStream()
+   // reports as a stream error.
    boost::iostreams::filtering_istream is;
    is.push(boost::iostreams::gzip_decompressor());
    is.push(*pIfs);
@@ -105,6 +102,44 @@ Error readGzippedSymbolMap(const FilePath& gzMapPath,
             boost::bind(parseSymbolMapLine, _1, _2, pSymbolsLeftToFind));
    if (error)
       error.addProperty("path", gzMapPath.getAbsolutePath());
+
+   return error;
+}
+
+Error validateGzipFile(const FilePath& gzPath)
+{
+   std::shared_ptr<std::istream> pIfs;
+   Error error = gzPath.openForRead(pIfs);
+   if (error)
+      return error;
+
+   // read the entire stream, discarding the output, so that zlib validates
+   // the whole payload including the trailer CRC. decompression failures
+   // (including a truncated trailer) set the stream's badbit.
+   try
+   {
+      boost::iostreams::filtering_istream is;
+      is.push(boost::iostreams::gzip_decompressor());
+      is.push(*pIfs);
+
+      char buffer[8192];
+      while (is.read(buffer, sizeof(buffer)))
+      {
+      }
+
+      if (is.bad())
+      {
+         error = systemError(boost::system::errc::io_error, ERROR_LOCATION);
+      }
+   }
+   catch(const std::exception& e)
+   {
+      error = systemError(boost::system::errc::io_error, ERROR_LOCATION);
+      error.addProperty("what", e.what());
+   }
+
+   if (error)
+      error.addProperty("path", gzPath.getAbsolutePath());
 
    return error;
 }
@@ -166,6 +201,33 @@ struct SymbolMaps::Impl
 {
    FilePath symbolMapsPath;
    SymbolCache symbolCache;
+   boost::mutex validationMutex;
+   std::map<std::string,bool> gzMapValidation;
+
+   // validate each gzipped symbol map's integrity once; reads after
+   // validation terminate early and skip the trailer CRC (see
+   // readGzippedSymbolMap)
+   bool validateGzippedSymbolMap(const FilePath& gzMapPath)
+   {
+      LOCK_MUTEX(validationMutex)
+      {
+         std::string path = gzMapPath.getAbsolutePath();
+         std::map<std::string,bool>::const_iterator it = gzMapValidation.find(path);
+         if (it != gzMapValidation.end())
+            return it->second;
+
+         Error error = validateGzipFile(gzMapPath);
+         if (error)
+            LOG_ERROR(error);
+
+         bool valid = !error;
+         gzMapValidation[path] = valid;
+         return valid;
+      }
+      END_LOCK_MUTEX
+
+      return false;
+   }
 
    std::string loadOneSymbol(const std::string& strongName,
                              const std::string& symbol)
@@ -210,7 +272,7 @@ struct SymbolMaps::Impl
             LOG_ERROR(error);
 
       }
-      else if (gzMapPath.exists())
+      else if (gzMapPath.exists() && validateGzippedSymbolMap(gzMapPath))
       {
          Error error = readGzippedSymbolMap(gzMapPath,
                                             &toReturn,

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -18,20 +18,19 @@
 #include <string>
 #include <map>
 #include <set>
-#include <sstream>
-#include <iterator>
 #include <algorithm>
 
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/bind/bind.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
 
 #include <core/Thread.hpp>
 #include <core/RegexUtils.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <core/FileSerializer.hpp>
-#include <core/ZlibUtil.hpp>
 
 using namespace boost::placeholders;
 
@@ -81,30 +80,27 @@ Error readGzippedSymbolMap(const FilePath& gzMapPath,
                            std::map<std::string,std::string>* pMap,
                            std::set<std::string>* pSymbolsLeftToFind)
 {
-   // read the compressed contents
    std::shared_ptr<std::istream> pIfs;
    Error error = gzMapPath.openForRead(pIfs);
    if (error)
       return error;
 
-   std::vector<unsigned char> compressedData(
-            (std::istreambuf_iterator<char>(*pIfs)),
-            std::istreambuf_iterator<char>());
+   // stream the decompression through the line parser, so that lookups can
+   // terminate early without inflating the whole file (as with the plain
+   // symbol map). decompression errors surface as stream failures, which
+   // readCollectionFromStream() reports.
+   boost::iostreams::filtering_istream is;
+   is.push(boost::iostreams::gzip_decompressor());
+   is.push(*pIfs);
 
-   // decompress, then parse lines as for the plain symbol map
-   std::string contents;
-   error = zlib::decompressGzip(compressedData, &contents);
-   if (error)
-   {
-      error.addProperty("path", gzMapPath.getAbsolutePath());
-      return error;
-   }
-
-   std::istringstream is(contents);
-   return readCollectionFromStream<std::map<std::string,std::string> >(
+   error = readCollectionFromStream<std::map<std::string,std::string> >(
             is,
             pMap,
             boost::bind(parseSymbolMapLine, _1, _2, pSymbolsLeftToFind));
+   if (error)
+      error.addProperty("path", gzMapPath.getAbsolutePath());
+
+   return error;
 }
 
 class SymbolCache : boost::noncopyable

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -267,6 +267,7 @@ struct SymbolMaps::Impl
       // read it from disk if it exists; packaged builds ship the symbol map
       // gzipped, so fall back to the compressed form when the plain file is
       // not available
+      bool cacheMissingSymbols = true;
       FilePath mapPath = symbolMapsPath.completeChildPath(strongName + ".symbolMap");
       FilePath gzMapPath = symbolMapsPath.completeChildPath(strongName + ".symbolMap.gz");
       if (mapPath.exists())
@@ -280,19 +281,32 @@ struct SymbolMaps::Impl
             LOG_ERROR(error);
 
       }
-      else if (gzMapPath.exists() && validateGzippedSymbolMap(gzMapPath))
+      else if (gzMapPath.exists())
       {
-         Error error = readGzippedSymbolMap(gzMapPath,
-                                            &toReturn,
-                                            &symbolsLeftToFind);
-         if (error)
-            LOG_ERROR(error);
+         if (validateGzippedSymbolMap(gzMapPath))
+         {
+            Error error = readGzippedSymbolMap(gzMapPath,
+                                               &toReturn,
+                                               &symbolsLeftToFind);
+            if (error)
+               LOG_ERROR(error);
+         }
+         else
+         {
+            // the file could not be validated or read, so leave the symbols
+            // uncached: a lookup after the file is repaired can then retry
+            // them (validation failures are not memoized either)
+            cacheMissingSymbols = false;
+         }
       }
 
       // mark all remaining symbols as having been looked for
-      for (const std::string& symbol : symbolsLeftToFind)
+      if (cacheMissingSymbols)
       {
-         toReturn[symbol] = SYMBOL_DATA_UNKNOWN;
+         for (const std::string& symbol : symbolsLeftToFind)
+         {
+            toReturn[symbol] = SYMBOL_DATA_UNKNOWN;
+         }
       }
 
       // add the return results to the cache

--- a/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
@@ -180,14 +180,20 @@ TEST(GwtSymbolMapsTest, RepairedGzippedSymbolMapIsRevalidated)
    StackElement resymbolized = maps.resymbolize(se, kStrongName);
    EXPECT_EQ(se.methodName, resymbolized.methodName);
 
-   // repair the file; a lookup for a symbol not yet poisoned by the failed
-   // attempt must trigger revalidation and succeed
+   // repair the file: both the symbol requested during the failure and a
+   // fresh one must now resolve, since neither the validation failure nor
+   // the affected symbols were cached
    std::shared_ptr<std::ostream> pOfs;
    ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
    pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
                sizeof(kSymbolMapContentsGz));
    ASSERT_TRUE(pOfs->good());
    pOfs.reset();
+
+   StackElement retried = maps.resymbolize(se, kStrongName);
+   EXPECT_EQ("com.example.gwt.Widget", retried.className);
+   EXPECT_EQ("render", retried.methodName);
+   EXPECT_EQ(105, retried.lineNumber);
 
    StackElement other;
    other.methodName = "Qb";

--- a/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
@@ -161,6 +161,46 @@ TEST(GwtSymbolMapsTest, CorruptGzippedSymbolMapReturnsOriginalElement)
    mapsDir.removeIfExists();
 }
 
+TEST(GwtSymbolMapsTest, RepairedGzippedSymbolMapIsRevalidated)
+{
+   FilePath mapsDir;
+   ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
+   ASSERT_FALSE(mapsDir.ensureDirectory());
+
+   FilePath gzMapPath = mapsDir.completeChildPath(std::string(kStrongName) + ".symbolMap.gz");
+   ASSERT_FALSE(writeStringToFile(gzMapPath, "not gzip data"));
+
+   SymbolMaps maps;
+   ASSERT_FALSE(maps.initialize(mapsDir));
+
+   // the damaged file fails validation, so the lookup comes back unchanged
+   StackElement se;
+   se.methodName = "Pb";
+   se.lineNumber = -1;
+   StackElement resymbolized = maps.resymbolize(se, kStrongName);
+   EXPECT_EQ(se.methodName, resymbolized.methodName);
+
+   // repair the file; a lookup for a symbol not yet poisoned by the failed
+   // attempt must trigger revalidation and succeed
+   std::shared_ptr<std::ostream> pOfs;
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
+               sizeof(kSymbolMapContentsGz));
+   ASSERT_TRUE(pOfs->good());
+   pOfs.reset();
+
+   StackElement other;
+   other.methodName = "Qb";
+   other.lineNumber = -1;
+   StackElement recovered = maps.resymbolize(other, kStrongName);
+
+   EXPECT_EQ("com.example.gwt.Widget", recovered.className);
+   EXPECT_EQ("layout", recovered.methodName);
+   EXPECT_EQ(42, recovered.lineNumber);
+
+   mapsDir.removeIfExists();
+}
+
 TEST(GwtSymbolMapsTest, UnknownSymbolReturnsOriginalElement)
 {
    FilePath mapsDir;

--- a/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
@@ -104,6 +104,38 @@ TEST(GwtSymbolMapsTest, ResymbolizesFromGzippedSymbolMap)
    mapsDir.removeIfExists();
 }
 
+TEST(GwtSymbolMapsTest, TruncatedGzippedSymbolMapReturnsOriginalElement)
+{
+   FilePath mapsDir;
+   ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
+   ASSERT_FALSE(mapsDir.ensureDirectory());
+
+   // strip the 8-byte gzip trailer (CRC + size): the deflate data is intact,
+   // so the symbols would still parse if the payload were not validated
+   FilePath gzMapPath = mapsDir.completeChildPath(std::string(kStrongName) + ".symbolMap.gz");
+   std::shared_ptr<std::ostream> pOfs;
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
+               sizeof(kSymbolMapContentsGz) - 8);
+   ASSERT_TRUE(pOfs->good());
+   pOfs.reset();
+
+   SymbolMaps maps;
+   ASSERT_FALSE(maps.initialize(mapsDir));
+
+   StackElement se;
+   se.className = "obfuscated";
+   se.methodName = "Pb";
+   se.lineNumber = 7;
+   StackElement resymbolized = maps.resymbolize(se, kStrongName);
+
+   EXPECT_EQ(se.className, resymbolized.className);
+   EXPECT_EQ(se.methodName, resymbolized.methodName);
+   EXPECT_EQ(se.lineNumber, resymbolized.lineNumber);
+
+   mapsDir.removeIfExists();
+}
+
 TEST(GwtSymbolMapsTest, CorruptGzippedSymbolMapReturnsOriginalElement)
 {
    FilePath mapsDir;

--- a/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
@@ -104,6 +104,31 @@ TEST(GwtSymbolMapsTest, ResymbolizesFromGzippedSymbolMap)
    mapsDir.removeIfExists();
 }
 
+TEST(GwtSymbolMapsTest, CorruptGzippedSymbolMapReturnsOriginalElement)
+{
+   FilePath mapsDir;
+   ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
+   ASSERT_FALSE(mapsDir.ensureDirectory());
+
+   FilePath gzMapPath = mapsDir.completeChildPath(std::string(kStrongName) + ".symbolMap.gz");
+   ASSERT_FALSE(writeStringToFile(gzMapPath, "not gzip data"));
+
+   SymbolMaps maps;
+   ASSERT_FALSE(maps.initialize(mapsDir));
+
+   StackElement se;
+   se.className = "obfuscated";
+   se.methodName = "Pb";
+   se.lineNumber = 7;
+   StackElement resymbolized = maps.resymbolize(se, kStrongName);
+
+   EXPECT_EQ(se.className, resymbolized.className);
+   EXPECT_EQ(se.methodName, resymbolized.methodName);
+   EXPECT_EQ(se.lineNumber, resymbolized.lineNumber);
+
+   mapsDir.removeIfExists();
+}
+
 TEST(GwtSymbolMapsTest, UnknownSymbolReturnsOriginalElement)
 {
    FilePath mapsDir;

--- a/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
@@ -207,6 +207,56 @@ TEST(GwtSymbolMapsTest, RepairedGzippedSymbolMapIsRevalidated)
    mapsDir.removeIfExists();
 }
 
+TEST(GwtSymbolMapsTest, GzippedSymbolMapReadFailureIsRetriable)
+{
+   FilePath mapsDir;
+   ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
+   ASSERT_FALSE(mapsDir.ensureDirectory());
+
+   FilePath gzMapPath = mapsDir.completeChildPath(std::string(kStrongName) + ".symbolMap.gz");
+   std::shared_ptr<std::ostream> pOfs;
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
+               sizeof(kSymbolMapContentsGz));
+   pOfs.reset();
+
+   // resolve one symbol so the file's validation result is memoized
+   SymbolMaps maps;
+   ASSERT_FALSE(maps.initialize(mapsDir));
+
+   StackElement se;
+   se.methodName = "Pb";
+   se.lineNumber = -1;
+   StackElement resymbolized = maps.resymbolize(se, kStrongName);
+   EXPECT_EQ("render", resymbolized.methodName);
+
+   // damage the file mid-stream: validation is already memoized, so the
+   // next lookup reaches the read itself, which must fail without caching
+   // the requested symbol as unknown
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz), 30);
+   pOfs.reset();
+
+   StackElement other;
+   other.methodName = "Qb";
+   other.lineNumber = -1;
+   StackElement damaged = maps.resymbolize(other, kStrongName);
+   EXPECT_EQ("Qb", damaged.methodName);
+
+   // repair the file: the same symbol must now resolve
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
+               sizeof(kSymbolMapContentsGz));
+   pOfs.reset();
+
+   StackElement recovered = maps.resymbolize(other, kStrongName);
+   EXPECT_EQ("com.example.gwt.Widget", recovered.className);
+   EXPECT_EQ("layout", recovered.methodName);
+   EXPECT_EQ(42, recovered.lineNumber);
+
+   mapsDir.removeIfExists();
+}
+
 TEST(GwtSymbolMapsTest, UnknownSymbolReturnsOriginalElement)
 {
    FilePath mapsDir;

--- a/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
@@ -257,6 +257,46 @@ TEST(GwtSymbolMapsTest, GzippedSymbolMapReadFailureIsRetriable)
    mapsDir.removeIfExists();
 }
 
+TEST(GwtSymbolMapsTest, PartialGzippedSymbolMapReadContributesNothing)
+{
+   FilePath mapsDir;
+   ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
+   ASSERT_FALSE(mapsDir.ensureDirectory());
+
+   // truncate near the end of the deflate data: earlier lines (including
+   // the requested symbol's) may decode before the stream fails, but a
+   // failed read must be all-or-nothing
+   FilePath gzMapPath = mapsDir.completeChildPath(std::string(kStrongName) + ".symbolMap.gz");
+   std::shared_ptr<std::ostream> pOfs;
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
+               sizeof(kSymbolMapContentsGz) - 19);
+   pOfs.reset();
+
+   SymbolMaps maps;
+   ASSERT_FALSE(maps.initialize(mapsDir));
+
+   StackElement se;
+   se.methodName = "Pb";
+   se.lineNumber = -1;
+   StackElement resymbolized = maps.resymbolize(se, kStrongName);
+   EXPECT_EQ(se.methodName, resymbolized.methodName);
+
+   // repair the file: the same symbol must resolve, proving the failed
+   // read neither negative-cached it nor cached partial results
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
+               sizeof(kSymbolMapContentsGz));
+   pOfs.reset();
+
+   StackElement retried = maps.resymbolize(se, kStrongName);
+   EXPECT_EQ("com.example.gwt.Widget", retried.className);
+   EXPECT_EQ("render", retried.methodName);
+   EXPECT_EQ(105, retried.lineNumber);
+
+   mapsDir.removeIfExists();
+}
+
 TEST(GwtSymbolMapsTest, UnknownSymbolReturnsOriginalElement)
 {
    FilePath mapsDir;

--- a/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
@@ -1,0 +1,131 @@
+/*
+ * GwtSymbolMapsTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/gwt/GwtSymbolMaps.hpp>
+
+#include <gtest/gtest.h>
+
+#include <core/FileSerializer.hpp>
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+
+namespace rstudio {
+namespace core {
+namespace gwt {
+
+namespace {
+
+const char* const kStrongName = "0123456789ABCDEF0123456789ABCDEF";
+
+const std::string kSymbolMapContents =
+      "# a comment line\n"
+      "Pb,com.example.gwt.Widget::render(I)V,com.example.gwt.Widget,render,com/example/gwt/Widget.java,105,0\n"
+      "Qb,com.example.gwt.Widget::layout()V,com.example.gwt.Widget,layout,com/example/gwt/Widget.java,42,0\n";
+
+// 'gzip -n' output for kSymbolMapContents, matching what the packaged
+// builds ship in www-symbolmaps
+const unsigned char kSymbolMapContentsGz[] = {
+   31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 83, 86, 72, 84, 72, 206,
+   207, 205, 77, 205, 43, 81, 200, 201, 204, 75, 229, 10, 72, 210, 1, 242,
+   245, 82, 43, 18, 115, 11, 114, 82, 245, 210, 203, 75, 244, 194, 51, 83,
+   210, 83, 75, 172, 172, 138, 82, 243, 82, 82, 139, 52, 60, 53, 195, 112,
+   40, 209, 129, 168, 0, 201, 234, 67, 101, 245, 129, 178, 250, 16, 89, 189,
+   172, 196, 178, 68, 29, 67, 3, 83, 29, 3, 174, 64, 220, 182, 228, 36,
+   86, 230, 151, 150, 104, 224, 182, 4, 162, 0, 175, 37, 38, 70, 64, 59,
+   0, 56, 113, 39, 166, 219, 0, 0, 0
+};
+
+} // anonymous namespace
+
+TEST(GwtSymbolMapsTest, ResymbolizesFromPlainSymbolMap)
+{
+   FilePath mapsDir;
+   ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
+   ASSERT_FALSE(mapsDir.ensureDirectory());
+
+   FilePath mapPath = mapsDir.completeChildPath(std::string(kStrongName) + ".symbolMap");
+   ASSERT_FALSE(writeStringToFile(mapPath, kSymbolMapContents));
+
+   SymbolMaps maps;
+   ASSERT_FALSE(maps.initialize(mapsDir));
+
+   StackElement se;
+   se.methodName = "Pb";
+   se.lineNumber = -1;
+   StackElement resymbolized = maps.resymbolize(se, kStrongName);
+
+   EXPECT_EQ("com.example.gwt.Widget", resymbolized.className);
+   EXPECT_EQ("render", resymbolized.methodName);
+   EXPECT_EQ("com/example/gwt/Widget.java", resymbolized.fileName);
+   EXPECT_EQ(105, resymbolized.lineNumber);
+
+   mapsDir.removeIfExists();
+}
+
+TEST(GwtSymbolMapsTest, ResymbolizesFromGzippedSymbolMap)
+{
+   FilePath mapsDir;
+   ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
+   ASSERT_FALSE(mapsDir.ensureDirectory());
+
+   FilePath gzMapPath = mapsDir.completeChildPath(std::string(kStrongName) + ".symbolMap.gz");
+   std::shared_ptr<std::ostream> pOfs;
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
+               sizeof(kSymbolMapContentsGz));
+   ASSERT_TRUE(pOfs->good());
+   pOfs.reset();
+
+   SymbolMaps maps;
+   ASSERT_FALSE(maps.initialize(mapsDir));
+
+   StackElement se;
+   se.methodName = "Qb";
+   se.lineNumber = -1;
+   StackElement resymbolized = maps.resymbolize(se, kStrongName);
+
+   EXPECT_EQ("com.example.gwt.Widget", resymbolized.className);
+   EXPECT_EQ("layout", resymbolized.methodName);
+   EXPECT_EQ("com/example/gwt/Widget.java", resymbolized.fileName);
+   EXPECT_EQ(42, resymbolized.lineNumber);
+
+   mapsDir.removeIfExists();
+}
+
+TEST(GwtSymbolMapsTest, UnknownSymbolReturnsOriginalElement)
+{
+   FilePath mapsDir;
+   ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
+   ASSERT_FALSE(mapsDir.ensureDirectory());
+
+   SymbolMaps maps;
+   ASSERT_FALSE(maps.initialize(mapsDir));
+
+   StackElement se;
+   se.className = "obfuscated";
+   se.methodName = "Zz";
+   se.lineNumber = 7;
+   StackElement resymbolized = maps.resymbolize(se, kStrongName);
+
+   EXPECT_EQ(se.className, resymbolized.className);
+   EXPECT_EQ(se.methodName, resymbolized.methodName);
+   EXPECT_EQ(se.lineNumber, resymbolized.lineNumber);
+
+   mapsDir.removeIfExists();
+}
+
+} // namespace gwt
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMapsTests.cpp
@@ -263,18 +263,41 @@ TEST(GwtSymbolMapsTest, PartialGzippedSymbolMapReadContributesNothing)
    ASSERT_FALSE(FilePath::tempFilePath(mapsDir));
    ASSERT_FALSE(mapsDir.ensureDirectory());
 
-   // truncate near the end of the deflate data: earlier lines (including
-   // the requested symbol's) may decode before the stream fails, but a
-   // failed read must be all-or-nothing
+   // 'gzip -n' output for a map containing only this symbol:
+   // Ab,com.example.gwt.Widget::prime()V,com.example.gwt.Widget,prime,com/example/gwt/Widget.java,1,0
+   const unsigned char primingMapGz[] = {
+      31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 115, 76, 210, 73, 206, 207,
+      213, 75, 173, 72, 204, 45, 200, 73, 213, 75, 47, 47, 209, 11, 207, 76,
+      73, 79, 45, 177, 178, 42, 40, 202, 204, 77, 213, 208, 12, 195, 161, 64,
+      7, 44, 15, 146, 212, 135, 74, 234, 3, 37, 245, 33, 146, 122, 89, 137,
+      101, 137, 58, 134, 58, 6, 92, 0, 50, 128, 178, 126, 97, 0, 0, 0
+   };
+
    FilePath gzMapPath = mapsDir.completeChildPath(std::string(kStrongName) + ".symbolMap.gz");
    std::shared_ptr<std::ostream> pOfs;
    ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
-   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
-               sizeof(kSymbolMapContentsGz) - 19);
+   pOfs->write(reinterpret_cast<const char*>(primingMapGz), sizeof(primingMapGz));
+   ASSERT_TRUE(pOfs->good());
    pOfs.reset();
 
+   // memoize successful validation without caching Pb, the symbol whose
+   // partially successful read we will test below
    SymbolMaps maps;
    ASSERT_FALSE(maps.initialize(mapsDir));
+
+   StackElement priming;
+   priming.methodName = "Ab";
+   priming.lineNumber = -1;
+   ASSERT_EQ("prime", maps.resymbolize(priming, kStrongName).methodName);
+
+   // replace the validated file with a truncated map: Pb decodes fully,
+   // then reading the incomplete Qb line fails before the parser can
+   // terminate. The parsed Pb entry must be discarded.
+   ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
+   pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
+               sizeof(kSymbolMapContentsGz) - 19);
+   ASSERT_TRUE(pOfs->good());
+   pOfs.reset();
 
    StackElement se;
    se.methodName = "Pb";
@@ -282,11 +305,17 @@ TEST(GwtSymbolMapsTest, PartialGzippedSymbolMapReadContributesNothing)
    StackElement resymbolized = maps.resymbolize(se, kStrongName);
    EXPECT_EQ(se.methodName, resymbolized.methodName);
 
+   // remove all decodable content: Pb must not resolve from a cached
+   // partial result left by the failed read
+   ASSERT_FALSE(writeStringToFile(gzMapPath, "not gzip data"));
+   EXPECT_EQ(se.methodName, maps.resymbolize(se, kStrongName).methodName);
+
    // repair the file: the same symbol must resolve, proving the failed
-   // read neither negative-cached it nor cached partial results
+   // reads did not cache it as unknown
    ASSERT_FALSE(gzMapPath.openForWrite(pOfs));
    pOfs->write(reinterpret_cast<const char*>(kSymbolMapContentsGz),
                sizeof(kSymbolMapContentsGz));
+   ASSERT_TRUE(pOfs->good());
    pOfs.reset();
 
    StackElement retried = maps.resymbolize(se, kStrongName);

--- a/src/cpp/core/include/core/FileSerializer.hpp
+++ b/src/cpp/core/include/core/FileSerializer.hpp
@@ -87,24 +87,18 @@ enum ReadCollectionAction
 };
    
 template <typename CollectionType>
-Error readCollectionFromFile(
-         const core::FilePath& filePath,
+Error readCollectionFromStream(
+         std::istream& is,
          CollectionType* pCollection,
-         boost::function<ReadCollectionAction(const std::string& line, 
+         boost::function<ReadCollectionAction(const std::string& line,
                                  typename CollectionType::value_type* pValue)>
                          parseFunction,
                          bool trimAndIgnoreBlankLines=true)
 {
    using namespace boost::system::errc;
-   
-   // open the file stream
-   std::shared_ptr<std::istream> pIfs;
-   Error error = filePath.openForRead(pIfs);
-   if (error)
-      return error;
-   
+
    // create insert iterator
-   std::insert_iterator<CollectionType> insertIterator(*pCollection, 
+   std::insert_iterator<CollectionType> insertIterator(*pCollection,
                                                        pCollection->begin());
 
    try
@@ -114,16 +108,16 @@ Error readCollectionFromFile(
       while (true)
       {
          // read the next line
-         std::getline(*pIfs, nextLine);
+         std::getline(is, nextLine);
 
-         if (pIfs->eof())
+         if (is.eof())
          {
             // only exit here if we have nothing to process
             // otherwise, exit after we have processed the data
             if (nextLine.empty())
                break;
          }
-         else if (pIfs->fail())
+         else if (is.fail())
             return systemError(io_error, ERROR_LOCATION);
 
          // trim whitespace then ignore it if it is a blank line
@@ -151,7 +145,7 @@ Error readCollectionFromFile(
          }
 
          // if we've hit the end of the file, we're done reading
-         if (pIfs->eof())
+         if (is.eof())
             break;
       }
    }
@@ -160,11 +154,35 @@ Error readCollectionFromFile(
       Error error = systemError(boost::system::errc::io_error,
                                 ERROR_LOCATION);
       error.addProperty("what", e.what());
-      error.addProperty("path", filePath.getAbsolutePath());
       return error;
    }
-   
+
    return Success();
+}
+
+template <typename CollectionType>
+Error readCollectionFromFile(
+         const core::FilePath& filePath,
+         CollectionType* pCollection,
+         boost::function<ReadCollectionAction(const std::string& line,
+                                 typename CollectionType::value_type* pValue)>
+                         parseFunction,
+                         bool trimAndIgnoreBlankLines=true)
+{
+   // open the file stream
+   std::shared_ptr<std::istream> pIfs;
+   Error error = filePath.openForRead(pIfs);
+   if (error)
+      return error;
+
+   error = readCollectionFromStream(*pIfs,
+                                    pCollection,
+                                    parseFunction,
+                                    trimAndIgnoreBlankLines);
+   if (error)
+      error.addProperty("path", filePath.getAbsolutePath());
+
+   return error;
 }
 
 template <typename ContentType>

--- a/src/cpp/core/include/core/ZlibUtil.hpp
+++ b/src/cpp/core/include/core/ZlibUtil.hpp
@@ -28,11 +28,6 @@ Error compressString(const std::string& toCompress, std::vector<unsigned char>* 
 
 Error decompressString(const std::vector<unsigned char>& compressedData, std::string* str);
 
-// decompress data in the gzip format (e.g. the contents of a .gz file);
-// note that this is a different format than the zlib format used by
-// compressString() / decompressString() above
-Error decompressGzip(const std::vector<unsigned char>& compressedData, std::string* str);
-
 } // namespace zlib
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/ZlibUtil.hpp
+++ b/src/cpp/core/include/core/ZlibUtil.hpp
@@ -28,6 +28,11 @@ Error compressString(const std::string& toCompress, std::vector<unsigned char>* 
 
 Error decompressString(const std::vector<unsigned char>& compressedData, std::string* str);
 
+// decompress data in the gzip format (e.g. the contents of a .gz file);
+// note that this is a different format than the zlib format used by
+// compressString() / decompressString() above
+Error decompressGzip(const std::vector<unsigned char>& compressedData, std::string* str);
+
 } // namespace zlib
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/ZlibUtil.hpp
+++ b/src/cpp/core/include/core/ZlibUtil.hpp
@@ -16,6 +16,9 @@
 #ifndef CORE_ZLIB_ZLIB_HPP
 #define CORE_ZLIB_ZLIB_HPP
 
+#include <iosfwd>
+#include <memory>
+#include <streambuf>
 #include <string>
 
 #include <shared_core/Error.hpp>
@@ -27,6 +30,33 @@ namespace zlib {
 Error compressString(const std::string& toCompress, std::vector<unsigned char>* compressedData);
 
 Error decompressString(const std::vector<unsigned char>& compressedData, std::string* str);
+
+// Presents a gzip stream, read incrementally from an underlying std::istream,
+// as a std::streambuf of decompressed bytes. Concatenated gzip members are
+// decompressed in sequence, as with gzip itself.
+//
+// Errors -- a corrupt or truncated stream, a trailer CRC mismatch, or a
+// failure reading the underlying stream -- are reported by throwing
+// std::runtime_error; a std::istream reading through this streambuf
+// surfaces that as badbit, distinguishing errors from a clean end of
+// stream (eofbit). The constructor itself may also throw if zlib fails
+// to initialize.
+class GzipDecompressingStreambuf : public std::streambuf
+{
+public:
+   explicit GzipDecompressingStreambuf(std::istream& source);
+   virtual ~GzipDecompressingStreambuf();
+
+   GzipDecompressingStreambuf(const GzipDecompressingStreambuf&) = delete;
+   GzipDecompressingStreambuf& operator=(const GzipDecompressingStreambuf&) = delete;
+
+protected:
+   int_type underflow() override;
+
+private:
+   struct Impl;
+   std::unique_ptr<Impl> pImpl_;
+};
 
 } // namespace zlib
 } // namespace core

--- a/src/cpp/server/DBActiveSessionStorageTests.cpp
+++ b/src/cpp/server/DBActiveSessionStorageTests.cpp
@@ -18,6 +18,23 @@ SqliteConnectionOptions sqliteConnectionOptions()
    return SqliteConnectionOptions { tempDb.getAbsolutePath() };
 }
 
+Result<std::string> readCreateTablesScript(const std::string& fileName)
+{
+   // the build stages the db/ schema folder next to this test executable, so
+   // resolve the script against the executable rather than the working
+   // directory the tests were launched from
+   FilePath exePath;
+   if (Error error = system::executablePath(nullptr, &exePath))
+      return Unexpected(error);
+
+   FilePath createDbPath = exePath.getParent().completeChildPath("db/" + fileName);
+   std::string createDbStr;
+   if (Error error = readStringFromFile(createDbPath, &createDbStr))
+      return Unexpected(error);
+
+   return createDbStr;
+}
+
 Result<boost::shared_ptr<IConnection>> initializeSQLiteDatabase(SqliteConnectionOptions options, system::User user)
 {
    // Delete the db if it exists
@@ -31,12 +48,10 @@ Result<boost::shared_ptr<IConnection>> initializeSQLiteDatabase(SqliteConnection
       return Unexpected(error);
 
    // Execute the create db script
-   FilePath workingDir = system::currentWorkingDir(system::currentProcessId());
-   FilePath createDbPath = workingDir.completeChildPath("db/CreateTables.sqlite");
-   std::string createDbStr;
-   if (Error error = readStringFromFile(createDbPath, &createDbStr))
-      return Unexpected(error);
-   if (Error error = connection->executeStr(createDbStr))
+   Result<std::string> createDbStr = readCreateTablesScript("CreateTables.sqlite");
+   if (!createDbStr)
+      return Unexpected(createDbStr.error());
+   if (Error error = connection->executeStr(*createDbStr))
       return Unexpected(error);
 
    // Insert a user to own the sessions
@@ -79,13 +94,11 @@ Result<boost::shared_ptr<IConnection>> initializePostgresqlDatabase(PostgresqlCo
    connection->executeStr("GRANT ALL ON SCHEMA public TO public");
 
    // Execute the create db script
-   FilePath workingDir = system::currentWorkingDir(system::currentProcessId());
-   FilePath createDbPath = workingDir.completeChildPath("db/CreateTables.postgresql");
-   std::string createDbStr;
-   if (Error error = readStringFromFile(createDbPath, &createDbStr))
-      return Unexpected(error);
+   Result<std::string> createDbStr = readCreateTablesScript("CreateTables.postgresql");
+   if (!createDbStr)
+      return Unexpected(createDbStr.error());
    connection->executeStr("BEGIN TRANSACTION");
-   if (Error error = connection->executeStr(createDbStr))
+   if (Error error = connection->executeStr(*createDbStr))
       return Unexpected(error);
    connection->executeStr("COMMIT");
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -863,15 +863,73 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
    endif()
 
    # install Copilot Language Server
+   #
+   # the copilot-language-server-js distribution bundles native binaries for
+   # every platform and architecture it supports; the binaries that can never
+   # run on the target platform account for the bulk of the distribution's
+   # size, so exclude them. revisit these patterns when updating the bundled
+   # Copilot version in case the package layout changes -- files that stop
+   # matching are installed again (larger package), never broken.
    if(RSTUDIO_ENABLE_COPILOT)
+
       if(APPLE)
-         install(DIRECTORY "${RSTUDIO_DEPENDENCIES_COPILOT_DIR}" 
+         set(COPILOT_EXCLUDED_PLATFORMS "linux|win32")
+      elseif(WIN32)
+         set(COPILOT_EXCLUDED_PLATFORMS "darwin|linux")
+      else()
+         set(COPILOT_EXCLUDED_PLATFORMS "darwin|win32")
+      endif()
+
+      set(COPILOT_EXCLUDES
+         REGEX "copilot-language-server-js/(bin|compiled)/(${COPILOT_EXCLUDED_PLATFORMS})$" EXCLUDE
+         REGEX "@github/copilot/sdk/prebuilds/(${COPILOT_EXCLUDED_PLATFORMS})-" EXCLUDE)
+
+      # mxc-bin mixes binaries for all platforms within its per-architecture
+      # folders, so those are excluded file-by-file; the crypt32*.node modules
+      # at the package root are Windows-only
+      if(WIN32)
+         list(APPEND COPILOT_EXCLUDES
+            REGEX "@github/copilot/mxc-bin/[^/]+/(linux-test-proxy|lxc-exec|mxc-exec-mac)$" EXCLUDE)
+      elseif(APPLE)
+         list(APPEND COPILOT_EXCLUDES
+            REGEX "@github/copilot/mxc-bin/[^/]+/(linux-test-proxy|lxc-exec)$" EXCLUDE
+            REGEX "@github/copilot/mxc-bin/[^/]+/[^/]+\\.(exe|dll)$" EXCLUDE
+            REGEX "copilot-language-server-js/crypt32[^/]*\\.node$" EXCLUDE)
+      else()
+         list(APPEND COPILOT_EXCLUDES
+            REGEX "@github/copilot/mxc-bin/[^/]+/mxc-exec-mac$" EXCLUDE
+            REGEX "@github/copilot/mxc-bin/[^/]+/[^/]+\\.(exe|dll)$" EXCLUDE
+            REGEX "copilot-language-server-js/crypt32[^/]*\\.node$" EXCLUDE)
+      endif()
+
+      # non-macOS packages are architecture-specific, so also exclude binaries
+      # built for the other architecture (macOS packages are universal and
+      # keep both)
+      if(NOT APPLE)
+         string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" COPILOT_TARGET_PROCESSOR)
+         if(COPILOT_TARGET_PROCESSOR MATCHES "^(x86_64|amd64)$")
+            set(COPILOT_EXCLUDED_ARCH "arm64")
+         elseif(COPILOT_TARGET_PROCESSOR MATCHES "^(aarch64|arm64)$")
+            set(COPILOT_EXCLUDED_ARCH "x64")
+         endif()
+         if(DEFINED COPILOT_EXCLUDED_ARCH)
+            list(APPEND COPILOT_EXCLUDES
+               REGEX "copilot-language-server-js/(bin|compiled)/[^/]+/${COPILOT_EXCLUDED_ARCH}$" EXCLUDE
+               REGEX "@github/copilot/sdk/prebuilds/[^/]+-${COPILOT_EXCLUDED_ARCH}$" EXCLUDE
+               REGEX "@github/copilot/mxc-bin/${COPILOT_EXCLUDED_ARCH}$" EXCLUDE)
+         endif()
+      endif()
+
+      if(APPLE)
+         install(DIRECTORY "${RSTUDIO_DEPENDENCIES_COPILOT_DIR}"
                DESTINATION "${RSTUDIO_INSTALL_RESOURCES}/app"
-               USE_SOURCE_PERMISSIONS)
+               USE_SOURCE_PERMISSIONS
+               ${COPILOT_EXCLUDES})
       else()
          install(DIRECTORY "${RSTUDIO_DEPENDENCIES_COPILOT_DIR}"
                DESTINATION "${RSTUDIO_INSTALL_BIN}"
-               USE_SOURCE_PERMISSIONS)
+               USE_SOURCE_PERMISSIONS
+               ${COPILOT_EXCLUDES})
       endif()
    endif()
 

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -192,7 +192,11 @@ if(GWT_COPY)
       get_filename_component(GWT_EXTRAS_ABSOLUTE_DIR "${GWT_EXTRAS_DIR}"
          ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
       install(CODE "
-         set(SYMBOL_MAPS_SOURCE_DIR \"${GWT_EXTRAS_ABSOLUTE_DIR}/rstudio/symbolMaps\")
+         # resolve symlinks (the folder exists by install time): the helper
+         # runs with this directory as its working directory, and
+         # file(ARCHIVE_CREATE) misresolves paths from symlinked directories
+         get_filename_component(SYMBOL_MAPS_SOURCE_DIR
+            \"${GWT_EXTRAS_ABSOLUTE_DIR}/rstudio/symbolMaps\" REALPATH)
          set(SYMBOL_MAPS_DIR \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps\")
          file(MAKE_DIRECTORY \"\${SYMBOL_MAPS_DIR}\")
          file(GLOB SYMBOL_MAPS \"\${SYMBOL_MAPS_SOURCE_DIR}/*.symbolMap\")

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -191,6 +191,11 @@ if(GWT_COPY)
       # runs with a different working directory and needs an absolute path
       get_filename_component(GWT_EXTRAS_ABSOLUTE_DIR "${GWT_EXTRAS_DIR}"
          ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+      # locate the gzip helper relative to this file: the top-level source
+      # directory need not be the repository root (e.g. cmake -S src)
+      get_filename_component(GZIP_HELPER_SCRIPT
+         "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/gzip-file.cmake" ABSOLUTE)
       install(CODE "
          # resolve symlinks (the folder exists by install time): the helper
          # runs with this directory as its working directory, and
@@ -207,7 +212,7 @@ if(GWT_COPY)
                COMMAND \"\${CMAKE_COMMAND}\"
                   \"-DINPUT=\${SYMBOL_MAP_NAME}\"
                   \"-DOUTPUT=\${SYMBOL_MAPS_DIR}/\${SYMBOL_MAP_NAME}.gz\"
-                  -P \"${CMAKE_SOURCE_DIR}/cmake/gzip-file.cmake\"
+                  -P \"${GZIP_HELPER_SCRIPT}\"
                WORKING_DIRECTORY \"\${SYMBOL_MAPS_SOURCE_DIR}\"
                RESULT_VARIABLE GZIP_RESULT)
             if(NOT GZIP_RESULT EQUAL 0)

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -153,24 +153,52 @@ if(GWT_COPY)
              GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
    # install local web resources
-   # we exclude WEB-INF here just in case a prior GWT build updated this
+   # we exclude WEB-INF here just in case a prior GWT build updated this;
+   # JavaScript source maps (e.g. panmirror's) are excluded since they are
+   # only useful when debugging with browser devtools
    install(
       DIRECTORY www
       DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}"
       PATTERN "WEB-INF" EXCLUDE
-      PATTERN ".gitignore" EXCLUDE)
+      PATTERN ".gitignore" EXCLUDE
+      REGEX "\\.js\\.map$" EXCLUDE)
 
    # install compiled GWT artefacts
    install(
       DIRECTORY "${GWT_WWW_DIR}"
       DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}"
       PATTERN "WEB-INF" EXCLUDE
-      PATTERN ".gitignore" EXCLUDE)
+      PATTERN ".gitignore" EXCLUDE
+      REGEX "\\.js\\.map$" EXCLUDE)
 
-   # copy symbol maps
-   install(
-      DIRECTORY "${GWT_EXTRAS_DIR}/rstudio/symbolMaps/"
-      DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps)
+   # copy symbol maps, gzipped to save space when supported -- they are only
+   # read when deobfuscating client-side stack traces for the log, and
+   # GwtSymbolMaps.cpp reads both the plain and gzipped forms
+   if(CMAKE_VERSION VERSION_LESS "3.18")
+      install(
+         DIRECTORY "${GWT_EXTRAS_DIR}/rstudio/symbolMaps/"
+         DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps)
+   else()
+      # GWT_EXTRAS_DIR may be relative to this source directory (as
+      # install(DIRECTORY) would resolve it); the install-time code below
+      # runs with a different working directory and needs an absolute path
+      get_filename_component(GWT_EXTRAS_ABSOLUTE_DIR "${GWT_EXTRAS_DIR}"
+         ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+      install(CODE "
+         set(SYMBOL_MAPS_DIR \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps\")
+         file(MAKE_DIRECTORY \"\${SYMBOL_MAPS_DIR}\")
+         file(GLOB SYMBOL_MAPS \"${GWT_EXTRAS_ABSOLUTE_DIR}/rstudio/symbolMaps/*.symbolMap\")
+         foreach(SYMBOL_MAP \${SYMBOL_MAPS})
+            get_filename_component(SYMBOL_MAP_NAME \"\${SYMBOL_MAP}\" NAME)
+            message(STATUS \"Compressing: \${SYMBOL_MAP_NAME}\")
+            file(ARCHIVE_CREATE
+               OUTPUT \"\${SYMBOL_MAPS_DIR}/\${SYMBOL_MAP_NAME}.gz\"
+               PATHS \"\${SYMBOL_MAP}\"
+               FORMAT raw
+               COMPRESSION GZip)
+         endforeach()
+      ")
+   endif()
 
 endif()
 

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -173,29 +173,42 @@ if(GWT_COPY)
 
    # copy symbol maps, gzipped to save space when supported -- they are only
    # read when deobfuscating client-side stack traces for the log, and
-   # GwtSymbolMaps.cpp reads both the plain and gzipped forms
+   # GwtSymbolMaps.cpp reads both the plain and gzipped forms. only the
+   # *.symbolMap files themselves are gzipped; any other files in the folder
+   # (e.g. the .symbolMapOffset read by ServerEval.cpp) are installed as-is
    if(CMAKE_VERSION VERSION_LESS "3.18")
       install(
          DIRECTORY "${GWT_EXTRAS_DIR}/rstudio/symbolMaps/"
          DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps)
    else()
+      install(
+         DIRECTORY "${GWT_EXTRAS_DIR}/rstudio/symbolMaps/"
+         DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps
+         PATTERN "*.symbolMap" EXCLUDE)
+
       # GWT_EXTRAS_DIR may be relative to this source directory (as
       # install(DIRECTORY) would resolve it); the install-time code below
       # runs with a different working directory and needs an absolute path
       get_filename_component(GWT_EXTRAS_ABSOLUTE_DIR "${GWT_EXTRAS_DIR}"
          ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
       install(CODE "
+         set(SYMBOL_MAPS_SOURCE_DIR \"${GWT_EXTRAS_ABSOLUTE_DIR}/rstudio/symbolMaps\")
          set(SYMBOL_MAPS_DIR \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps\")
          file(MAKE_DIRECTORY \"\${SYMBOL_MAPS_DIR}\")
-         file(GLOB SYMBOL_MAPS \"${GWT_EXTRAS_ABSOLUTE_DIR}/rstudio/symbolMaps/*.symbolMap\")
+         file(GLOB SYMBOL_MAPS \"\${SYMBOL_MAPS_SOURCE_DIR}/*.symbolMap\")
          foreach(SYMBOL_MAP \${SYMBOL_MAPS})
             get_filename_component(SYMBOL_MAP_NAME \"\${SYMBOL_MAP}\" NAME)
             message(STATUS \"Compressing: \${SYMBOL_MAP_NAME}\")
-            file(ARCHIVE_CREATE
-               OUTPUT \"\${SYMBOL_MAPS_DIR}/\${SYMBOL_MAP_NAME}.gz\"
-               PATHS \"\${SYMBOL_MAP}\"
-               FORMAT raw
-               COMPRESSION GZip)
+            execute_process(
+               COMMAND \"\${CMAKE_COMMAND}\"
+                  \"-DINPUT=\${SYMBOL_MAP_NAME}\"
+                  \"-DOUTPUT=\${SYMBOL_MAPS_DIR}/\${SYMBOL_MAP_NAME}.gz\"
+                  -P \"${CMAKE_SOURCE_DIR}/cmake/gzip-file.cmake\"
+               WORKING_DIRECTORY \"\${SYMBOL_MAPS_SOURCE_DIR}\"
+               RESULT_VARIABLE GZIP_RESULT)
+            if(NOT GZIP_RESULT EQUAL 0)
+               message(FATAL_ERROR \"Failed to compress \${SYMBOL_MAP_NAME}\")
+            endif()
          endforeach()
       ")
    endif()

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -175,8 +175,9 @@ if(GWT_COPY)
    # read when deobfuscating client-side stack traces for the log, and
    # GwtSymbolMaps.cpp reads both the plain and gzipped forms. only the
    # *.symbolMap files themselves are gzipped; any other files in the folder
-   # (e.g. the .symbolMapOffset read by ServerEval.cpp) are installed as-is
-   if(CMAKE_VERSION VERSION_LESS "3.18")
+   # (e.g. the .symbolMapOffset read by ServerEval.cpp) are installed as-is.
+   # (3.19 is required for file(CHMOD) in the gzip-file.cmake helper)
+   if(CMAKE_VERSION VERSION_LESS "3.19")
       install(
          DIRECTORY "${GWT_EXTRAS_DIR}/rstudio/symbolMaps/"
          DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps)


### PR DESCRIPTION
Fixes #18738.

This PR reduces the installed size of RStudio through four independent changes. On macOS, the installed application shrinks from ~1.9 GB to ~800 MB on disk, and the download shrinks by roughly 250 MB; Linux and Windows packages see similar (smaller) reductions.

## 1. Exclude other platforms' Copilot Language Server binaries

The `copilot-language-server-js` distribution bundles native binaries for every platform and architecture it supports (`sdk/prebuilds` for six platform/arch combos, `mxc-bin` with Linux ELF and Windows PE executables, per-platform `bin`/`compiled` folders, Windows-only `crypt32*.node`). RStudio installed all of it -- a macOS install shipped ~230 MB of binaries that can never load there.

The install rules in `src/cpp/session/CMakeLists.txt` now exclude non-target platforms (and, on the architecture-specific Linux/Windows packages, the other architecture; macOS universal builds keep both). Verified against the real dependency tree: 359M becomes 127M (macOS), 101M (Linux x64), 117M (Windows x64), with the platform-appropriate files retained in each case. The runtime resolves these folders via `process.platform`/`process.arch`, so the removed files are unreachable on the target platform. If a future Copilot update changes its layout, unmatched patterns simply fall back to installing more files, never to breakage.

## 2. Stop packaging JavaScript source maps

`www/js/panmirror/panmirror.js.map` (20 MB, larger than panmirror.js itself) was shipped in every package. Source maps are only fetched when browser devtools are open, and nothing else references them. The `www` install rules now exclude `*.js.map`. Development workflows are unaffected (devmode serves from the source tree, not the installed tree). Quarto's bundled source maps are left alone to avoid diverging from the upstream quarto distribution.

## 3. Ship GWT symbol maps compressed

The GWT symbol map (34 MB of text) is read only when deobfuscating client-side stack traces for the log. It is now gzipped at install time (34M -> 2M) via a `cmake/gzip-file.cmake` helper invoked with an explicit working directory (`file(ARCHIVE_CREATE)` misresolves paths from symlinked working directories), with installed permissions normalized to 644 and a plain-copy fallback for CMake < 3.19. Sidecar files in the symbol maps folder (such as the `.symbolMapOffset` read by `ServerEval.cpp`) are installed unchanged.

At runtime, `GwtSymbolMaps` reads both the plain and gzipped forms. Gzipped maps are streamed through a zlib-backed `GzipDecompressingStreambuf` into the existing line parser, so lookups terminate early without inflating the whole file. Each file's integrity is validated once up front (full drain, trailer CRC checked) with successful validations memoized by path; validation failures and read failures are not cached -- neither the verdict nor the requested symbols -- so a damaged file that is later repaired recovers on the next lookup, and a read that fails partway contributes nothing to the symbol cache.

## 4. Transparently compress the macOS application bundle

`make-package` now runs `ditto --hfsCompression` over the signed bundle before building the DMG, storing files APFS/HFS+-compressed (decmpfs). This is transparent to all readers and roughly halves the bundle's on-disk size. Verified locally against a production build (RStudio 2026.08.2+200):

- full bundle: 1.9G -> 803M on disk, compression takes ~8 seconds
- `codesign --verify --deep --strict` passes on the compressed bundle ("valid on disk / satisfies its Designated Requirement"); signatures cover logical file contents, which are unchanged
- compression survives `hdiutil create` into a DMG, mounting, and `ditto`/Finder-style copies out of it (verified with checksums); copies made with tools that do not preserve the attribute silently fall back to full size
- a `codesign --verify --deep --strict` guard recursively verifies nested code after compression in the packaging script

## macOS Asio runtime fix

This PR also retains commit `444f692c6d`, which removes `BOOST_ASIO_DISABLE_KQUEUE`. The workaround addressed a Boost bug fixed in 1.45; this branch uses Boost 1.91. Keeping it forced macOS Asio onto `select`, which cannot handle descriptors numbered at or above `FD_SETSIZE` (1024). `ProcessTest.MultipleAsyncProcessesResults` starts up to 1,000 children with redirected pipes and exposed that limit during validation of this PR.

The removal intentionally switches macOS Asio I/O from `select` to `kqueue`. It is retained here to fix the process-test failure encountered while validating the package changes, and remains in its own commit so the runtime change can be traced and reverted independently. The process stress test passes locally using kqueue. This is an additional runtime fix; it does not contribute to the package-size reduction.

## Tests

- `GwtSymbolMapsTests.cpp` covers plain, gzipped, truncated, corrupt, repaired-file recovery, post-validation read failure, partial-read all-or-nothing, and unknown-symbol resymbolization (the gzipped fixture is real `gzip -n` output)
- earlier local validation built the `all` target and passed the core suite apart from `ProcessTest.MultipleAsyncProcessesResults`; the retained kqueue fix addresses that failure
- follow-up validation on macOS arm64 rebuilt `rstudio-core-tests` and passed all 14 focused gzip, GWT symbol-map, and process stress tests; this follow-up did not rerun the full core suite or rebuild a DMG
- the partial-read regression test primes validation with a separate symbol, verifies that parsed results from a later failed read are neither returned nor cached, and verifies recovery after repair; temporarily parsing directly into the return map makes the test fail
- `bash -n package/osx/make-package` and `git diff --check` pass
- install-rule behavior verified by running the generated install rules against the real dependency trees for all three platforms, from symlinked and non-symlinked working directories, and under a restrictive umask
- the branch passed an iterative roborev review loop (findings addressed: preserve symbol-map sidecar files, symlink-safe gzip helper invocation, streaming decompression with early termination, one-time integrity validation with retriable failures, all-or-nothing reads, deterministic installed permissions, helper path resolution independent of the top-level source dir)

