### PR TITLE
Add --only-database test flag to restrict to DB-backed tests

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -24,9 +24,10 @@ fi
 read -r -d '' USAGE <<- EOF
 Run RStudio unit tests. Available flags:
 
---help    Show this help.
---scope   Run only tests with the given scope (core, rserver, rsession, r).
---filter  Run a subset of R tests, matching the requested filter.
+--help           Show this help.
+--scope          Run only tests with the given scope (core, rserver, rsession, r).
+--filter         Run a subset of R tests, matching the requested filter.
+--only-database  Restrict the rserver scope to the database-backed fixture tests.
 EOF
 
 section () {
@@ -184,6 +185,12 @@ while [ $# -gt 0 ]; do
 
    ;;
 
+   "--only-database")
+      ONLY_DATABASE=true
+      shift
+
+   ;;
+
    "--help")
       echo "${USAGE}"
       exit 0
@@ -274,7 +281,13 @@ if has-scope "rserver"; then
    if [ -e "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests" ]; then
       section "Running 'rserver' tests..."
       cd server
-      runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests"
+      # Database-backed fixture tests (named *IntegrationTest) run alongside
+      # the rest of the suite by default; --only-database narrows to just those.
+      RSERVER_TESTS_ARGS=""
+      if [ "${ONLY_DATABASE:-false}" = "true" ]; then
+         RSERVER_TESTS_ARGS="--only-database"
+      fi
+      runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests ${RSERVER_TESTS_ARGS}"
       cd ..
    fi
 

--- a/src/cpp/server/TestMain.cpp
+++ b/src/cpp/server/TestMain.cpp
@@ -124,11 +124,17 @@ int main(int argc, char* argv[])
    // Without --log, no logging is initialized so automation output stays clean.
    // The RSTUDIO_TEST_LOG_LEVEL env var also works (--log flag takes priority).
    // Recognized levels: DEBUG, INFO, WARN (default), ERR/ERROR.
+   //
+   // --only-database (or RSTUDIO_ONLY_DATABASE=1) restricts the run to the
+   // database-backed fixture tests (the *IntegrationTest suites), skipping
+   // everything else -- used to rerun just those against a real PostgreSQL
+   // instance without repeating the rest of the suite.
    using namespace rstudio::core;
    bool enableLog = false;
    log::LogLevel logLevel = log::LogLevel::WARN;
+   bool onlyDatabase = false;
 
-   // Scan argv for --log or --log=LEVEL, removing it so gtest doesn't see it.
+   // Scan argv for our custom flags, removing them so gtest doesn't see them.
    for (int i = 1; i < argc; )
    {
       std::string arg(argv[i]);
@@ -148,6 +154,13 @@ int main(int argc, char* argv[])
             argv[j] = argv[j + 1];
          --argc;
       }
+      else if (arg == "--only-database")
+      {
+         onlyDatabase = true;
+         for (int j = i; j < argc - 1; ++j)
+            argv[j] = argv[j + 1];
+         --argc;
+      }
       else
       {
          ++i;
@@ -155,7 +168,7 @@ int main(int argc, char* argv[])
    }
    argv[argc] = nullptr;
 
-   // Fall back to env var if --log was not specified
+   // Fall back to env vars if the flags were not specified
    if (!enableLog)
    {
       const char* logLevelEnv = std::getenv("RSTUDIO_TEST_LOG_LEVEL");
@@ -163,6 +176,16 @@ int main(int argc, char* argv[])
       {
          enableLog = true;
          logLevel = parseLogLevel(std::string(logLevelEnv));
+      }
+   }
+
+   if (!onlyDatabase)
+   {
+      const char* onlyDatabaseEnv = std::getenv("RSTUDIO_ONLY_DATABASE");
+      if (onlyDatabaseEnv &&
+          (std::string(onlyDatabaseEnv) == "1" || std::string(onlyDatabaseEnv) == "true"))
+      {
+         onlyDatabase = true;
       }
    }
 
@@ -177,5 +200,9 @@ int main(int argc, char* argv[])
    }
 
    testing::InitGoogleTest(&argc, argv);
+
+   if (onlyDatabase)
+      GTEST_FLAG_SET(filter, "*IntegrationTest*");
+
    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
<!-- include an entry in NEWS.md if required -->

### Intent

Companion for rstudio-pro #12576, which unifies database-backed test fixtures behind a new `--only-database` flag on `rserver-tests`. This ports just that flag plumbing here so `TestMain.cpp` and `rstudio-tests.in` — both shared verbatim between the two repos — don't drift apart. The flag is a no-op in this repo for now, since nothing here is named `*IntegrationTest*` yet.

### Approach

Mirrors the pro-side diff, minus the `rserver-admin-tests` skip (that binary doesn't exist in this repo).

### Automated Tests

None added; there's nothing for the new filter to match yet in this repo.

### QA Notes

Not tied to a tracked issue; no QA notes to update.

### Documentation

None.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
