### PR TITLE
rewrite multipart parsing

### DIFF
--- a/src/cpp/core/http/RequestParserTests.cpp
+++ b/src/cpp/core/http/RequestParserTests.cpp
@@ -63,6 +63,7 @@ struct FormTester
          }
       );
    }
+   FormTester(const FormTester&) = delete;
 
    bool handle(const std::string& formData, bool complete)
    {
@@ -164,7 +165,6 @@ struct FormTester
    std::string buffer;
    Error validationError;
    Request request;
-   FormHandler handler;
    RequestParser parser;
    const char* parseIter = nullptr;
    const char* endIter = nullptr;

--- a/src/cpp/core/http/RequestParserTests.cpp
+++ b/src/cpp/core/http/RequestParserTests.cpp
@@ -88,12 +88,17 @@ struct FormTester
       const std::string& name,
       const std::string& data,
       const std::string& contentType = std::string(),
-      const std::string& filename = std::string()
+      const std::string& filename = std::string(),
+      bool quoteName = true
    )
    {
       std::ostringstream ss;
       ss << "\r\n--" << boundary << "\r\n";
-      ss << "Content-Disposition: form-data; name=\"" << name << '"';
+      ss << "Content-Disposition: form-data; name=";
+      if (quoteName)
+        ss << "\"" << name << '"';
+      else
+        ss << name;
       if (!filename.empty())
          ss << "; filename=\"" << filename << '"';
       ss << "\r\n";
@@ -390,6 +395,35 @@ TEST(HttpTest, FormParsingEdgeCases)
 
    File file = form.request.uploadedFile("field2");
    EXPECT_EQ(file.name, "semicolon;and\"quote.txt");
+}
+
+TEST(HttpTest, FormParsingEdgeCases2)
+{
+   FormTester form;
+   form.expectedData = form.multipart("field1", "value1") +
+      "\r\n--boundary --" +
+      form.multipart("fie\"ld2", "test", "text/plain", "filename.txt") +
+      "\r\n--boundary--";
+
+   form.requestStr = "POST /test HTTP/1.1\r\n"
+      "Host: example.com\r\n"
+      "Content-Type: multipart/form-data; Boundary=\"boundary\" \r\n"
+      "Content-Length: " + std::to_string(form.expectedData.size()) +
+      "\r\n\r\n" + form.expectedData;
+
+   RequestParser::status status = form.parse();
+   ASSERT_EQ(RequestParser::headers_parsed, status);
+
+   status = form.parse();
+   EXPECT_EQ(RequestParser::form_complete, status);
+
+   EXPECT_FALSE(form.validationError) << form.validationError;
+
+   EXPECT_EQ(form.request.formFieldValue("field1"), "value1\r\n--boundary --");
+
+   File file = form.request.uploadedFile("fie\"ld2");
+   EXPECT_EQ(file.name, "filename.txt");
+   EXPECT_TRUE(file.contents == "test") << "uploaded file contents mismatch";
 }
 
 TEST(HttpTest, FormParsingBoundaryTrailingSpaces)

--- a/src/cpp/core/http/RequestParserTests.cpp
+++ b/src/cpp/core/http/RequestParserTests.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <boost/make_shared.hpp>
+#include <boost/algorithm/string/replace.hpp>
 
 #include <core/http/RequestParser.hpp>
 #include <shared_core/SafeConvert.hpp>
@@ -32,31 +33,6 @@ namespace rstudio {
 namespace core {
 namespace http {
 namespace tests {
-
-std::string simpleRequest(std::string* pBodyStr)
-{
-   std::string bodyStr =
-         "--boundary\r\n"
-         "Content-Disposition: form-data; name=\"field1\"\r\n\r\n"
-         "value1\r\n"
-         "--boundary\r\n"
-         "Content-Disposition: form-data; name=\"field2\"; filename=\"example.txt\"\r\n"
-         "Content-Type: text/plain\r\n\r\n"
-         "This is a simple text file\r\n"
-         "--boundary--\r\n";
-
-   *pBodyStr = bodyStr;
-
-   std::string bodySizeStr = safe_convert::numberToString(bodyStr.size());
-
-   std::string requestStr =
-         "POST /test HTTP/1.1\r\n"
-         "Host: foo.example\r\n"
-         "Content-Type: multipart/form-data; boundary=boundary\r\n"
-         "Content-Length: " + bodySizeStr + "\r\n\r\n" + bodyStr;
-
-   return requestStr;
-}
 
 core::Result<std::string> generateRandomBytes()
 {
@@ -76,107 +52,166 @@ core::Result<std::string> generateRandomBytes()
    return fileBytes;
 }
 
-std::string complexRequest(const std::string& fileBytes,
-                           std::string* pBodyStr)
+struct FormTester
 {
-   std::string bodyStr =
-         "--boundary\r\n"
-         "Content-Disposition: form-data; name=\"field1\"\r\n\r\n"
-         "value1\r\n"
-         "--boundary\r\n"
-         "Content-Disposition: form-data; name=\"field2\"; filename=\"example.txt\"\r\n"
-         "Content-Type: application/octet-stream\r\n\r\n" +
-         fileBytes + "\r\n"
-         "--boundary--\r\n";
-
-   *pBodyStr = bodyStr;
-
-   std::string bodySizeStr = safe_convert::numberToString(bodyStr.size());
-
-   std::string requestStr =
-         "POST /test HTTP/1.1\r\n"
-         "Host: foo.example\r\n"
-         "Content-Type: multipart/form-data; boundary=boundary\r\n"
-         "Content-Length: " + bodySizeStr + "\r\n\r\n" + bodyStr;
-
-   return requestStr;
-}
-
-core::Result<FormHandler> formHandler(const std::string& expectedData)
-{
-   boost::shared_ptr<std::string> data = boost::make_shared<std::string>();
-
-   bool valid = true;
-   auto handler = [=, &valid](const std::string& formData, bool complete) -> bool
+   FormTester(const std::string& boundary = "boundary") : boundary(boundary)
    {
-      (*data) += formData;
+      parser.setFormHandler(
+         [this](const std::string& formData, bool complete) -> bool
+         {
+            return handle(formData, complete);
+         }
+      );
+   }
 
+   bool handle(const std::string& formData, bool complete)
+   {
+      buffer += formData;
       if (complete)
       {
-         if(*data != expectedData){
-            valid = false;
+         request.setBody(buffer);
+         if (buffer != expectedData)
+         {
+            validationError = systemError(
+               boost::system::errc::invalid_argument,
+               "Form handler validation failed",
+               ERROR_LOCATION
+            );
+            return false;
          }
+         buffer.clear();
       }
       return true;
-   };
+   }
 
-   if(!valid)
+   std::string multipart(
+      const std::string& name,
+      const std::string& data,
+      const std::string& contentType = std::string(),
+      const std::string& filename = std::string()
+   )
    {
-      return tl::unexpected(systemError(boost::system::errc::invalid_argument,
-                                        "Form handler validation failed",
-                                        ERROR_LOCATION));
-   }  
-   return handler;
-}
+      std::ostringstream ss;
+      ss << "\r\n--" << boundary << "\r\n";
+      ss << "Content-Disposition: form-data; name=\"" << name << '"';
+      if (!filename.empty())
+         ss << "; filename=\"" << filename << '"';
+      ss << "\r\n";
+      if (!contentType.empty())
+         ss << "Content-Type: " << contentType << "\r\n";
+      ss << "\r\n";
+      ss << data;
+      return ss.str();
+   }
+
+   void simpleRequest()
+   {
+      complexRequest("This is a simple text file", "text/plain");
+   }
+
+   void complexRequest(const std::string& data, const std::string& contentType)
+   {
+      expectedData = multipart("field1", "value1") +
+         multipart("field2", data, contentType, "example.txt") +
+         "\r\n--" + boundary + "--";
+
+      requestStr = "POST /test HTTP/1.1\r\n"
+         "Host: example.com\r\n"
+         "Content-Type: multipart/form-data; boundary=" + boundary + "\r\n"
+         "Content-Length: " + std::to_string(expectedData.size()) +
+         "\r\n\r\n" + expectedData;
+   }
+
+   RequestParser::status parse()
+   {
+      const char* begin = requestStr.c_str();
+      const char* end = begin + requestStr.size();
+      return parser.parse(request, begin, end);
+   }
+
+   RequestParser::status parseBytes(int count)
+   {
+      if (!parseIter)
+      {
+         parseIter = requestStr.c_str();
+         endIter = parseIter + requestStr.size();
+      }
+
+      const char* stepEnd = parseIter + count;
+      if (stepEnd > endIter)
+         stepEnd = endIter;
+
+      RequestParser::status status = parser.parse(request, parseIter, stepEnd);
+      if (status != RequestParser::headers_parsed && status != RequestParser::form_complete)
+         parseIter = stepEnd;
+
+      return status;
+   }
+
+   bool eof() const
+   {
+      return !parseIter || parseIter >= endIter;
+   }
+
+   std::string boundary;
+   std::string expectedData;
+   std::string requestStr;
+   std::string buffer;
+   Error validationError;
+   Request request;
+   FormHandler handler;
+   RequestParser parser;
+   const char* parseIter = nullptr;
+   const char* endIter = nullptr;
+};
 
 TEST(HttpTest, SimpleFormParsingWorks)
 {
-   std::string bodyStr;
-   std::string requestStr = simpleRequest(&bodyStr);
-   Request request;
+   FormTester form;
+   form.simpleRequest();
 
-   auto handlerResult = formHandler(bodyStr);
-   ASSERT_TRUE(handlerResult.has_value()) << handlerResult.error().getSummary();
-   FormHandler handler = *handlerResult;
-
-   RequestParser parser;
-   parser.setFormHandler(handler);
-
-   RequestParser::status status = parser.parse(request, requestStr.c_str(), requestStr.c_str() + requestStr.size());
+   RequestParser::status status = form.parse();
    ASSERT_EQ(RequestParser::headers_parsed, status);
 
-   status = parser.parse(request, requestStr.c_str(), requestStr.c_str() + requestStr.size());
+   status = form.parse();
    ASSERT_EQ(RequestParser::form_complete, status);
+
+   EXPECT_FALSE(form.validationError) << form.validationError;
+
+   EXPECT_EQ(form.request.formFieldValue("field1"), "value1");
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_FALSE(file.empty());
+   EXPECT_EQ(file.name, "example.txt");
+   EXPECT_EQ(file.contentType, "text/plain");
+   EXPECT_EQ(file.contents, "This is a simple text file");
 }
 
 TEST(HttpTest, SimpleFormParsingWorksOneByteAtATime)
 {
-   std::string bodyStr;
-   std::string requestStr = simpleRequest(&bodyStr);
-   Request request;
-
-   auto handlerResult = formHandler(bodyStr);
-   ASSERT_TRUE(handlerResult.has_value()) << handlerResult.error().getSummary();
-   FormHandler handler = *handlerResult;
-
-   RequestParser parser;
-   parser.setFormHandler(handler);
+   FormTester form;
+   form.simpleRequest();
 
    RequestParser::status status;
-   for (size_t i = 0; i < requestStr.size() - 1; ++i)
+   do
    {
-      status = parser.parse(request, requestStr.c_str() + i, requestStr.c_str() + i + 1);
+      status = form.parseBytes(1);
+      if (status == RequestParser::form_complete)
+         break;
       ASSERT_TRUE(status == RequestParser::headers_parsed || status == RequestParser::incomplete);
-
-      if (status == rstudio::core::http::RequestParser::headers_parsed)
-      {
-         // need to pass the same buffer to resume
-         i--;
-      }
    }
+   while (!form.eof());
+   ASSERT_EQ(status, RequestParser::form_complete);
 
-   status = parser.parse(request, requestStr.c_str() + requestStr.size() - 1, requestStr.c_str() + requestStr.size());
-   ASSERT_EQ(RequestParser::form_complete, status);
+   EXPECT_FALSE(form.validationError) << form.validationError;
+
+   EXPECT_EQ(form.request.formFieldValue("field1"), "value1");
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_FALSE(file.empty());
+   EXPECT_EQ(file.name, "example.txt");
+   EXPECT_EQ(file.contentType, "text/plain");
+   EXPECT_EQ(file.contents, "This is a simple text file");
 }
 
 TEST(HttpTest, ComplicatedFormParsingWorks)
@@ -185,22 +220,22 @@ TEST(HttpTest, ComplicatedFormParsingWorks)
    ASSERT_TRUE(result.has_value()) << result.error().getSummary();
    const std::string& fileBytes = *result;
 
-   std::string bodyStr;
-   std::string requestStr = complexRequest(fileBytes, &bodyStr);
-   Request request;
+   FormTester form;
+   form.complexRequest(fileBytes, "application/octet-stream");
 
-   auto handlerResult = formHandler(bodyStr);
-   ASSERT_TRUE(handlerResult.has_value()) << handlerResult.error().getSummary();
-   FormHandler handler = *handlerResult;
-
-   RequestParser parser;
-   parser.setFormHandler(handler);
-
-   RequestParser::status status = parser.parse(request, requestStr.c_str(), requestStr.c_str() + requestStr.size());
+   RequestParser::status status = form.parse();
    ASSERT_EQ(RequestParser::headers_parsed, status);
 
-   status = parser.parse(request, requestStr.c_str(), requestStr.c_str() + requestStr.size());
+   status = form.parse();
    ASSERT_EQ(RequestParser::form_complete, status);
+
+   EXPECT_EQ(form.request.formFieldValue("field1"), "value1");
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_FALSE(file.empty());
+   EXPECT_EQ(file.name, "example.txt");
+   EXPECT_EQ(file.contentType, "application/octet-stream");
+   EXPECT_TRUE(file.contents == fileBytes) << "uploaded file contents mismatch";
 }
 
 TEST(HttpTest, ComplicatedFormParsingWorksOneByteAtATime)
@@ -209,32 +244,27 @@ TEST(HttpTest, ComplicatedFormParsingWorksOneByteAtATime)
    ASSERT_TRUE(result.has_value()) << result.error().getSummary();
    const std::string& fileBytes = *result;
 
-   std::string bodyStr;
-   std::string requestStr = complexRequest(fileBytes, &bodyStr);
-   Request request;
-
-   auto handlerResult = formHandler(bodyStr);
-   ASSERT_TRUE(handlerResult.has_value()) << handlerResult.error().getSummary();
-   FormHandler handler = *handlerResult;
-
-   RequestParser parser;
-   parser.setFormHandler(handler);
+   FormTester form;
+   form.complexRequest(fileBytes, "application/octet-stream");
 
    RequestParser::status status;
-   for (size_t i = 0; i < requestStr.size() - 1; ++i)
+   do
    {
-      status = parser.parse(request, requestStr.c_str() + i, requestStr.c_str() + i + 1);
+      status = form.parseBytes(1);
+      if (status == RequestParser::form_complete)
+         break;
       ASSERT_TRUE(status == RequestParser::headers_parsed || status == RequestParser::incomplete);
-
-      if (status == rstudio::core::http::RequestParser::headers_parsed)
-      {
-         // need to pass the same buffer to resume
-         i--;
-      }
    }
+   while (!form.eof());
+   ASSERT_EQ(status, RequestParser::form_complete);
 
-   status = parser.parse(request, requestStr.c_str() + requestStr.size() - 1, requestStr.c_str() + requestStr.size());
-   ASSERT_EQ(RequestParser::form_complete, status);
+   EXPECT_EQ(form.request.formFieldValue("field1"), "value1");
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_FALSE(file.empty());
+   EXPECT_EQ(file.name, "example.txt");
+   EXPECT_EQ(file.contentType, "application/octet-stream");
+   EXPECT_TRUE(file.contents == fileBytes) << "uploaded file contents mismatch";
 }
 
 TEST(HttpTest, ComplicatedFormParsingWorksRandomByteBoundaries)
@@ -242,42 +272,149 @@ TEST(HttpTest, ComplicatedFormParsingWorksRandomByteBoundaries)
    auto result = generateRandomBytes();
    ASSERT_TRUE(result.has_value()) << result.error().getSummary();
    const std::string& fileBytes = *result;
-
-   std::string bodyStr;
-   std::string requestStr = complexRequest(fileBytes, &bodyStr);
-   Request request;
-
-   auto handlerResult = formHandler(bodyStr);
-   ASSERT_TRUE(handlerResult.has_value()) << handlerResult.error().getSummary();
-   FormHandler handler = *handlerResult;
-
-   RequestParser parser;
-   parser.setFormHandler(handler);
+   FormTester form;
+   form.complexRequest(fileBytes, "application/octet-stream");
 
    RequestParser::status status;
-
-   for (size_t i = 0; i < requestStr.size();)
+   size_t blockSize = 0;
+   do
    {
-      size_t byteAmount = rand() % 8192 + 1;
-      if (byteAmount > requestStr.size() - i)
-         byteAmount = requestStr.size() - i;
-
-      status = parser.parse(request, requestStr.c_str() + i, requestStr.c_str() + i + byteAmount);
-      ASSERT_TRUE(status == RequestParser::headers_parsed || status == RequestParser::incomplete || status == RequestParser::form_complete);
-
-      if (status == rstudio::core::http::RequestParser::headers_parsed)
-      {
-         // need to pass the same buffer to resume
-         status = parser.parse(request, requestStr.c_str() + i, requestStr.c_str() + i + byteAmount);
-         ASSERT_EQ(rstudio::core::http::RequestParser::incomplete, status);
-      }
-      else if (status == rstudio::core::http::RequestParser::form_complete)
-      {
+      blockSize = rand() % 8192 + 1;
+      status = form.parseBytes(blockSize);
+      if (status == RequestParser::form_complete)
          break;
-      }
-
-      i += byteAmount;
+      ASSERT_TRUE(status == RequestParser::headers_parsed || status == RequestParser::incomplete);
    }
+   while (!form.eof());
+   ASSERT_EQ(status, RequestParser::form_complete);
+
+   EXPECT_EQ(form.request.formFieldValue("field1"), "value1");
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_FALSE(file.empty());
+   EXPECT_EQ(file.name, "example.txt");
+   EXPECT_EQ(file.contentType, "application/octet-stream");
+   EXPECT_TRUE(file.contents == fileBytes) << "uploaded file contents mismatch";
+}
+
+TEST(HttpTest, FormParsingRejectsMalformedMultipart)
+{
+   FormTester form("");
+   form.simpleRequest();
+
+   RequestParser::status status = form.parse();
+   ASSERT_EQ(RequestParser::headers_parsed, status);
+
+   status = form.parse();
+   ASSERT_EQ(RequestParser::form_complete, status);
+
+   EXPECT_EQ(form.request.formFields().size(), 0);
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_TRUE(file.empty());
+}
+
+TEST(HttpTest, FormParsingToleratesMissingPreamble)
+{
+   FormTester form;
+   form.simpleRequest();
+   boost::algorithm::replace_first(form.requestStr, "\r\n\r\n\r\n", "\r\n\r\n");
+   boost::algorithm::replace_first(form.requestStr,
+      "Content-Length: " + std::to_string(form.expectedData.size()),
+      "Content-Length: " + std::to_string(form.expectedData.size() - 2)
+   );
+   form.expectedData.erase(form.expectedData.begin(), form.expectedData.begin() + 2);
+
+   RequestParser::status status = form.parse();
+   ASSERT_EQ(RequestParser::headers_parsed, status);
+
+   status = form.parse();
+   EXPECT_EQ(RequestParser::form_complete, status);
+
+   EXPECT_FALSE(form.validationError) << form.validationError;
+
+   EXPECT_EQ(form.request.formFieldValue("field1"), "value1");
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_FALSE(file.empty());
+   EXPECT_EQ(file.name, "example.txt");
+   EXPECT_EQ(file.contentType, "text/plain");
+   EXPECT_EQ(file.contents, "This is a simple text file");
+}
+
+TEST(HttpTest, FormParsingIgnoresEpilogue)
+{
+   FormTester form;
+   form.simpleRequest();
+   std::string extra = form.multipart("field3", "value3");
+   extra = extra.substr(extra.find("Content-Disposition"));
+   boost::algorithm::replace_first(form.requestStr,
+      "Content-Length: " + std::to_string(form.expectedData.size()),
+      "Content-Length: " + std::to_string(form.expectedData.size() + extra.size())
+   );
+   form.requestStr += extra;
+   form.expectedData += extra;
+
+   RequestParser::status status = form.parse();
+   ASSERT_EQ(RequestParser::headers_parsed, status);
+
+   status = form.parse();
+   EXPECT_EQ(RequestParser::form_complete, status);
+
+   EXPECT_FALSE(form.validationError) << form.validationError;
+
+   EXPECT_EQ(form.request.formFieldValue("field1"), "value1");
+   EXPECT_EQ(form.request.formFieldValue("field3"), std::string());
+}
+
+TEST(HttpTest, FormParsingEdgeCases)
+{
+   FormTester form;
+   form.expectedData = form.multipart("field1", "value1") +
+      form.multipart("field2", "test", "text/plain", "semicolon;and\\\"quote.txt") +
+      "\r\n--boundary--";
+
+   form.requestStr = "POST /test HTTP/1.1\r\n"
+      "Host: example.com\r\n"
+      "Content-Type: multipart/form-data; Boundary=\"boundary\" \r\n"
+      "Content-Length: " + std::to_string(form.expectedData.size()) +
+      "\r\n\r\n" + form.expectedData;
+
+   RequestParser::status status = form.parse();
+   ASSERT_EQ(RequestParser::headers_parsed, status);
+
+   status = form.parse();
+   EXPECT_EQ(RequestParser::form_complete, status);
+
+   EXPECT_FALSE(form.validationError) << form.validationError;
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_EQ(file.name, "semicolon;and\"quote.txt");
+}
+
+TEST(HttpTest, FormParsingBoundaryTrailingSpaces)
+{
+   FormTester form("boundary \t ");
+   form.expectedData = form.multipart("field1", "value1") +
+      form.multipart("field2", "test", "text/plain", "semi\\\\colon;and\\\"quote\\.txt") +
+      "\r\n--boundary--";
+
+   form.requestStr = "POST /test HTTP/1.1\r\n"
+      "Host: example.com\r\n"
+      "Content-Type: multipart/form-data; Boundary=\"boundary\" \r\n"
+      "Content-Length: " + std::to_string(form.expectedData.size()) +
+      "\r\n\r\n" + form.expectedData;
+
+   RequestParser::status status = form.parse();
+   ASSERT_EQ(RequestParser::headers_parsed, status);
+
+   status = form.parse();
+   EXPECT_EQ(RequestParser::form_complete, status);
+
+   EXPECT_FALSE(form.validationError) << form.validationError;
+
+   File file = form.request.uploadedFile("field2");
+   EXPECT_EQ(file.name, "semi\\colon;and\"quote.txt");
 }
 
 } // namespace tests

--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -17,17 +17,21 @@
 #include <core/http/Util.hpp>
 
 #include <cstdio>
+#include <cctype>
 #include <ios>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <algorithm>
 
 #include <boost/asio.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/algorithm/string/find_iterator.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
 #include <boost/regex.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 
@@ -49,12 +53,12 @@ namespace http {
 
 namespace util {
 
-   
+
 Fields::const_iterator findField(const Fields& fields, const std::string& name)
 {
    return std::find_if(fields.begin(), fields.end(), FieldPredicate(name));
 }
-   
+
 std::string fieldValue(const Fields& fields, const std::string& name)
 {
    Fields::const_iterator pos = findField(fields, name);
@@ -63,11 +67,11 @@ std::string fieldValue(const Fields& fields, const std::string& name)
    else
       return std::string();
 }
-   
-void parseFields(const std::string& fields, 
-                 const char* fieldDelim, 
+
+void parseFields(const std::string& fields,
+                 const char* fieldDelim,
                  const char* valueDelim,
-                 Fields* pFields, 
+                 Fields* pFields,
                  FieldDecodeType fieldDecode)
 {
    // enable straightforward references to tokenizer class & helpers
@@ -79,7 +83,7 @@ void parseFields(const std::string& fields,
 
    // iterate over the fields
    tokenizer<char_separator<char> > fieldTokens(fields, fieldSeparator);
-   for (tokenizer<char_separator<char> >::iterator 
+   for (tokenizer<char_separator<char> >::iterator
          fieldIter = fieldTokens.begin();
          fieldIter != fieldTokens.end();
          ++fieldIter)
@@ -105,11 +109,11 @@ void parseFields(const std::string& fields,
          pFields->push_back(std::make_pair(name,value));
    }
 }
-   
+
 void buildQueryString(const Fields& fields, std::string* pQueryString)
 {
    pQueryString->clear();
-   
+
    for (Fields::const_iterator it = fields.begin();
         it != fields.end();
         ++it)
@@ -121,117 +125,335 @@ void buildQueryString(const Fields& fields, std::string* pQueryString)
       pQueryString->append(encodedValue);
       pQueryString->append("&");
    }
-   
+
    // remove trailing &
    if (!pQueryString->empty())
       pQueryString->erase(pQueryString->length()-1);
 }
-   
+
 void parseForm(const std::string& body, Fields* pFields)
 {
    return parseFields(body, "&", "=", pFields, FieldDecodeForm);
 }
-   
-   
+
 void parseQueryString(const std::string& queryString, Fields* pFields)
 {
    return parseFields(queryString, "&", "=", pFields, FieldDecodeQueryString);
 }
-      
+
+struct SemiFinder
+{
+   template <typename ITER>
+   boost::iterator_range<ITER> operator()(ITER begin, ITER end) const {
+      bool inQuotes = false;
+      bool escape = false;
+      for (ITER iter = begin; iter != end; iter++)
+      {
+         if (escape)
+         {
+            escape = false;
+         }
+         else if (*iter == '\\')
+         {
+            escape = true;
+         }
+         else if (*iter == '"')
+         {
+            inQuotes = !inQuotes;
+         }
+         else if (!inQuotes && *iter == ';')
+         {
+            return boost::iterator_range<ITER>(iter, iter + 1);
+         }
+      }
+      return boost::iterator_range<ITER>(end, end);
+   }
+} semiFinder;
+
+struct BoundaryFinder
+{
+   BoundaryFinder(const std::string_view& boundary) : boundary(boundary) {}
+
+   std::string boundary;
+
+   enum State {
+      NeedLeadingCR,
+      NeedLeadingLF,
+      NeedDash1,
+      NeedDash2,
+      NeedString,
+      NeedTrailingCR,
+      NeedTrailingLF,
+      NeedTerminatorDash2,
+   };
+
+   template <typename ITER>
+   boost::iterator_range<ITER> operator()(ITER begin, ITER end) const {
+      using Range = boost::iterator_range<ITER>;
+
+      // empty range matches nothing
+      if (begin == end)
+      {
+         return Range(end, end);
+      }
+
+      State state = NeedLeadingCR;
+      size_t matchPos = 0;
+      ITER matchStart = begin;
+      if (*begin == '-')
+      {
+         state = NeedDash2;
+         ++begin;
+      }
+      for (ITER iter = begin; iter != end; iter++)
+      {
+         char ch = *iter;
+         // Keep track of the start of the match
+         if (state == NeedLeadingCR)
+            matchStart = iter;
+         // Reset the state machine on an unexpected \r
+         if (state != NeedTrailingCR && ch == '\r')
+         {
+            state = NeedLeadingLF;
+            matchStart = iter;
+            continue;
+         }
+         switch (state)
+         {
+            case NeedLeadingCR:
+               // ignore everything but \r, which is handled above
+               break;
+            case NeedLeadingLF:
+               if (ch == '\n')
+                  state = NeedDash1;
+               else
+                  state = NeedLeadingCR;
+               break;
+            case NeedDash1:
+            case NeedDash2:
+               matchPos = 0;
+               if (ch == '-')
+                  state = (state == NeedDash1) ? NeedDash2 : NeedString;
+               else
+                  state = NeedLeadingCR;
+               break;
+            case NeedString:
+               if (ch == boundary[matchPos])
+               {
+                  matchPos++;
+                  if (matchPos == boundary.size())
+                     state = NeedTrailingCR;
+               }
+               else
+                  state = NeedLeadingCR;
+               break;
+            case NeedTrailingCR:
+               if (ch == '\r')
+                  state = NeedTrailingLF;
+               else if (ch == '-')
+                  state = NeedTerminatorDash2;
+               else if (ch != ' ' && ch != '\t')
+                  state = NeedLeadingCR;
+               break;
+            case NeedTrailingLF:
+               if (ch == '\n')
+                  return Range(matchStart, iter + 1);
+               state = NeedLeadingCR;
+               break;
+            case NeedTerminatorDash2:
+               if (ch == '-')
+                  return Range(matchStart, end);
+               state = NeedLeadingCR;
+               break;
+         }
+      }
+      return Range(end, end);
+   }
+};
+
+struct HeaderParams
+{
+   std::vector<std::string> values;
+   std::map<std::string, std::string> params;
+
+   template <typename RANGE>
+   static HeaderParams parse(const RANGE& headerRange)
+   {
+      namespace ba = boost::algorithm;
+
+      HeaderParams result;
+      std::string_view header(&*headerRange.begin(), headerRange.size());
+
+      auto fields = ba::make_split_iterator(header, semiFinder);
+
+      for (; !fields.eof(); fields++)
+      {
+         auto start = fields->begin();
+         auto end = fields->end();
+         while (start != end && std::isspace(std::uint8_t(*start)))
+            ++start;
+         while (start != end && std::isspace(std::uint8_t(*(end - 1))))
+            --end;
+
+         auto eqPos = start;
+         while (eqPos != end && *eqPos != '=')
+            ++eqPos;
+         if (eqPos == end)
+         {
+            if (end != start)
+               result.values.emplace_back(&*start, end - start);
+            continue;
+         }
+         std::string key(&*start, eqPos - start);
+         boost::algorithm::to_lower(key);
+
+         std::string_view value(&*eqPos + 1, end - eqPos - 1);
+         // strip quotes
+         if (value.size() >= 2 && value.front() == '"' && value.back() == '"')
+         {
+            value.remove_prefix(1);
+            value.remove_suffix(1);
+            std::string valueStr;
+            valueStr.reserve(value.size());
+            bool escape = false;
+            for (char ch : value)
+            {
+               if (escape)
+               {
+                  escape = false;
+               }
+               else if (ch == '\\')
+               {
+                  escape = true;
+                  continue;
+               }
+               valueStr.push_back(ch);
+            }
+            result.params.emplace(key, valueStr);
+         }
+         else
+         {
+            result.params.emplace(key, value);
+         }
+      }
+      return result;
+   }
+};
+
+
 void parseMultipartForm(const std::string& contentType,
-                        const std::string& body, 
+                        const std::string& body,
                         Fields* pFields,
                         Files* pFiles)
 {
+   namespace ba = boost::algorithm;
    // get the boundary token
-   std::string boundaryPrefix("boundary=");
-   std::string boundary;
-   size_t prefixLoc = contentType.find(boundaryPrefix);
-   if (prefixLoc != std::string::npos)
+   HeaderParams ctParams = HeaderParams::parse(contentType);
+   std::string boundary(ctParams.params["boundary"]);
+   if (boundary.empty())
    {
-      boundary = contentType.substr(prefixLoc+boundaryPrefix.size(),
-                                    std::string::npos);
-      boundary = "--" + boundary;
-      boost::algorithm::trim(boundary);
+      // No boundary token: malformed multipart/form-data
+      LOG_WARNING_MESSAGE("Invalid multipart/form-data content-type: missing boundary");
+      return;
    }
-   
-   // extract the fields
-   size_t beginBoundaryLoc = body.find(boundary);
-   size_t endBoundaryLoc = body.find("\r\n" + boundary,
-                                     beginBoundaryLoc+boundary.size());
-   while (endBoundaryLoc != std::string::npos)
+
+   // Per RFC 1341, multipart-body ends immediately after the `--` with no CRLF necessary.
+   size_t terminatorPos = body.find("\r\n--" + boundary + "--");
+   if (!terminatorPos || !body.size())
    {
-      // extract the part into a string stream
-      size_t beginPart = beginBoundaryLoc + boundary.size();
-      size_t partLength = endBoundaryLoc - beginPart;
-      std::istringstream partStream(body.substr(beginPart, partLength));
+      // No sections, just a terminating boundary
+      LOG_WARNING_MESSAGE("Invalid multipart/form-data: no sections");
+      return;
+   }
+   // Be permissinve beyond the strict requirements of RFC 1341:
+   // Use best effort to read the last part even if the terminator is missing.
+   if (terminatorPos == std::string::npos)
+      terminatorPos = body.size();
+
+   std::string_view multipart(&*body.begin(), terminatorPos);
+
+   // iterate over the multipart sections
+   BoundaryFinder finder(boundary);
+   auto iter = ba::make_split_iterator(multipart, finder);
+   auto endIter = ba::split_iterator<std::string_view::const_iterator>();
+   bool isPreamble = true;
+   for (; iter != endIter; ++iter)
+   {
+      auto partRange = *iter;
+      if (isPreamble)
+      {
+         // Always ignore the preamble before the first multipart boundary
+         isPreamble = false;
+         continue;
+      }
+
+      // wrap in non-copying stream
+      boost::iostreams::filtering_istream partStream(partRange);
       partStream.unsetf(std::ios::skipws);
-    
+
       // read the headers
       Headers headers;
       http::parseHeaders(partStream, &headers);
-      
-      // check for content-disposition
-      std::string cDisp = http::headerValue(headers,"Content-Disposition");
-      if (!cDisp.empty())
+
+      // get the content-disposition header
+      std::string cDispStr = http::headerValue(headers, "Content-Disposition");
+      if (cDispStr.empty())
+         continue;
+
+      // ignore sections that aren't form-data
+      HeaderParams cDisp = HeaderParams::parse(cDispStr);
+      if (cDisp.values.empty() || boost::algorithm::to_lower_copy(cDisp.values.front()) != "form-data")
+         continue;
+
+      auto nameIter = cDisp.params.find("name");
+      if (nameIter == cDisp.params.end())
       {
-         // parse values out of content disposition
-         std::string nameRegex("form-data; name=\"(.*)\"");
-         boost::smatch nameMatch;
-         if (regex_utils::match(cDisp, nameMatch, boost::regex(nameRegex)))
-         {
-            // read the rest of the stream
-            std::ostringstream valueStream;
-            std::copy(std::istream_iterator<char>(partStream),
-                      std::istream_iterator<char>(),
-                      std::ostream_iterator<char>(valueStream));
-                       
-            // check for filename
-            std::string filenameRegex(nameRegex + "; filename=\"(.*)\"");
-            boost::smatch fileMatch;
-            if (regex_utils::match(cDisp, fileMatch, boost::regex(filenameRegex)))
-            {
-               std::string name(fileMatch[1]);
-               
-               File uploadedFile;
-               uploadedFile.name = fileMatch[2];
-               uploadedFile.contentType = http::headerValue(headers, 
-                                                            "Content-Type");
-               if (uploadedFile.contentType.empty())
-                  uploadedFile.contentType = "application/octet-stream";
-               
-               uploadedFile.contents = valueStream.str();
-               pFiles->insert(std::make_pair(name, uploadedFile));
-            }
-            // else process regular form field
-            else
-            {
-               std::string name(nameMatch[1]);
-               std::string value = valueStream.str();
-               boost::algorithm::trim(value);
-               pFields->push_back(std::make_pair(name, value));
-            }
-         }
-         
+         // name is required, so if it's missing, skip the entire section
+         continue;
       }
-                
-      // next boundary
-      beginBoundaryLoc = endBoundaryLoc;
-      endBoundaryLoc = body.find("\r\n" + boundary,
-                                 beginBoundaryLoc+boundary.size());
+
+      std::string formName(nameIter->second);
+
+      auto filenameIter = cDisp.params.find("filename");
+      if (filenameIter != cDisp.params.end() && pFiles->find(formName) != pFiles->end())
+      {
+         // If we've already processed a file upload for a given form field,
+         // keep the first file and ignore the rest without allocating any
+         // additional memory.
+         continue;
+      }
+
+      std::string formValue(partRange.size(), '\0');
+      partStream.read(formValue.data(), partRange.size());
+      formValue.resize(partStream.gcount());
+
+      if (filenameIter != cDisp.params.end())
+      {
+         File& uploadedFile = (*pFiles)[formName];
+         uploadedFile.name = filenameIter->second;
+         uploadedFile.contentType = http::headerValue(headers, "Content-Type");
+         if (uploadedFile.contentType.empty())
+            uploadedFile.contentType = "application/octet-stream";
+         uploadedFile.contents.swap(formValue);
+      }
+      else
+      {
+         boost::algorithm::trim(formValue);
+         pFields->emplace_back(formName, std::move(formValue));
+      }
    }
-}   
-   
+}
+
 
 std::string urlEncode(const std::string& in, bool queryStringSpaces)
 {
    std::string encodedURL;
-      
+
    size_t inputLength = in.length();
    for (size_t i=0; i<inputLength; i++)
    {
       char ch = in[i];
-      
+
       if ( ('0' <= ch && ch <= '9') ||
            ('a' <= ch && ch <= 'z') ||
            ('A' <= ch && ch <= 'Z') ||
@@ -254,10 +476,10 @@ std::string urlEncode(const std::string& in, bool queryStringSpaces)
          encodedURL += charAsHex;
       }
    }
-   
+
    return encodedURL;
 }
-   
+
 std::string urlDecode(const std::string& in)
 {
    std::string out;
@@ -298,7 +520,7 @@ std::string urlDecode(const std::string& in)
    }
    return out;
 }
-   
+
 namespace {
 
 const char * const kHttpDateFormat = "%a, %d %b %Y %H:%M:%S GMT";
@@ -317,7 +539,7 @@ boost::posix_time::time_input_facet s_httpDateInputFacet(kHttpDateFormat, 1);
 boost::posix_time::ptime parseDate(const std::string& date, const char* format)
 {
    using namespace boost::posix_time;
-   
+
    // Warning - creating the time_input_facet is fairly expensive so avoiding it for http date
    // facet for date (construct w/ a_ref == 1 so we manage memory)
    time_input_facet dateFacet(1);
@@ -331,15 +553,15 @@ boost::posix_time::ptime parseDate(const std::string& date, const char* format)
    dateStream >> posixDate;
 
    return posixDate;
-}   
+}
 
 }
-   
-boost::posix_time::ptime parseAtomDate(const std::string& date)   
+
+boost::posix_time::ptime parseAtomDate(const std::string& date)
 {
    return parseDate(date, kAtomDateFormat);
 }
-   
+
 
 boost::posix_time::ptime parseHttpDate(const std::string& date)
 {
@@ -354,11 +576,11 @@ boost::posix_time::ptime parseHttpDate(const std::string& date)
 
    return posixDate;
 }
-   
+
 std::string httpDate(const boost::posix_time::ptime& datetime)
 {
    using namespace boost::posix_time;
-   
+
    // output and return the date
    std::ostringstream dateStream;
    dateStream.imbue(std::locale(dateStream.getloc(), &s_httpDateFacet));
@@ -395,7 +617,7 @@ std::string pathAfterPrefix(const Request& request,
 {
    // get the raw uri & strip its location prefix
    std::string uri = URL::cleanupPath(request.uri());
-   
+
    if (!pathPrefix.empty() && !uri.compare(0, pathPrefix.length(), pathPrefix))
       uri = uri.substr(pathPrefix.length());
 

--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -16,8 +16,8 @@
 
 #include <core/http/Util.hpp>
 
-#include <cstdio>
 #include <cctype>
+#include <cstdio>
 #include <ios>
 #include <iostream>
 #include <sstream>
@@ -26,10 +26,11 @@
 
 #include <boost/asio.hpp>
 #include <boost/tokenizer.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/find_iterator.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/regex.hpp>
@@ -141,12 +142,17 @@ void parseQueryString(const std::string& queryString, Fields* pFields)
    return parseFields(queryString, "&", "=", pFields, FieldDecodeQueryString);
 }
 
+namespace {
+
 struct SemiFinder
 {
    template <typename ITER>
-   boost::iterator_range<ITER> operator()(ITER begin, ITER end) const {
+   boost::iterator_range<ITER> operator()(ITER begin, ITER end) const
+   {
       bool inQuotes = false;
       bool escape = false;
+      bool readyQuote = false;
+      bool foundEq = false;
       for (ITER iter = begin; iter != end; iter++)
       {
          if (escape)
@@ -157,7 +163,7 @@ struct SemiFinder
          {
             escape = true;
          }
-         else if (*iter == '"')
+         else if (*iter == '"' && (inQuotes || readyQuote))
          {
             inQuotes = !inQuotes;
          }
@@ -165,6 +171,16 @@ struct SemiFinder
          {
             return boost::iterator_range<ITER>(iter, iter + 1);
          }
+         else if (!inQuotes && *iter == '=')
+         {
+            if (!foundEq)
+            {
+               foundEq = true;
+               readyQuote = true;
+               continue;
+            }
+         }
+         readyQuote = false;
       }
       return boost::iterator_range<ITER>(end, end);
    }
@@ -176,12 +192,14 @@ struct BoundaryFinder
 
    std::string boundary;
 
-   enum State {
+   enum State
+   {
       NeedLeadingCR,
       NeedLeadingLF,
       NeedDash1,
       NeedDash2,
       NeedString,
+      NeedTrailingCROrDash,
       NeedTrailingCR,
       NeedTrailingLF,
       NeedTerminatorDash2,
@@ -212,7 +230,7 @@ struct BoundaryFinder
          if (state == NeedLeadingCR)
             matchStart = iter;
          // Reset the state machine on an unexpected \r
-         if (state != NeedTrailingCR && ch == '\r')
+         if (state != NeedTrailingCR && state != NeedTrailingCROrDash && ch == '\r')
          {
             state = NeedLeadingLF;
             matchStart = iter;
@@ -242,18 +260,21 @@ struct BoundaryFinder
                {
                   matchPos++;
                   if (matchPos == boundary.size())
-                     state = NeedTrailingCR;
+                     state = NeedTrailingCROrDash;
                }
                else
                   state = NeedLeadingCR;
                break;
+            case NeedTrailingCROrDash:
             case NeedTrailingCR:
                if (ch == '\r')
                   state = NeedTrailingLF;
-               else if (ch == '-')
+               else if (ch == '-' && state == NeedTrailingCROrDash)
                   state = NeedTerminatorDash2;
                else if (ch != ' ' && ch != '\t')
                   state = NeedLeadingCR;
+               else
+                  state = NeedTrailingCR;
                break;
             case NeedTrailingLF:
                if (ch == '\n')
@@ -282,6 +303,9 @@ struct HeaderParams
       namespace ba = boost::algorithm;
 
       HeaderParams result;
+      if (!headerRange.size())
+        return result;
+
       std::string_view header(&*headerRange.begin(), headerRange.size());
 
       auto fields = ba::make_split_iterator(header, semiFinder);
@@ -340,6 +364,8 @@ struct HeaderParams
    }
 };
 
+}
+
 
 void parseMultipartForm(const std::string& contentType,
                         const std::string& body,
@@ -357,15 +383,15 @@ void parseMultipartForm(const std::string& contentType,
       return;
    }
 
-   // Per RFC 1341, multipart-body ends immediately after the `--` with no CRLF necessary.
+   // Per RFC 2046, multipart-body ends immediately after the `--` with no CRLF necessary.
    size_t terminatorPos = body.find("\r\n--" + boundary + "--");
-   if (!terminatorPos || !body.size())
+   if (terminatorPos == 0 || !body.size())
    {
       // No sections, just a terminating boundary
       LOG_WARNING_MESSAGE("Invalid multipart/form-data: no sections");
       return;
    }
-   // Be permissinve beyond the strict requirements of RFC 1341:
+   // Be permissive beyond the strict requirements of RFC 2046:
    // Use best effort to read the last part even if the terminator is missing.
    if (terminatorPos == std::string::npos)
       terminatorPos = body.size();


### PR DESCRIPTION
### Intent

Backports a fix from rstudio-pro. The MIME multipart parsing had a number of flaws, so it got replaced with one that's more spec-compliant.

### Approach

Basically just a full rewrite.

### Automated Tests

Properly covered by unit tests.

### Documentation

Internal bugfix, N/A. News file was already updated in pro.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
