### PR TITLE
Harden R startup caches against abandoned static initialization guards

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -
 
 ### Fixed
+- ([#18718](https://github.com/rstudio/rstudio/issues/18718)): Hardened R option and version cache initialization against R errors leaving a C++ static-initialization guard locked during session startup.
 -
 
 ### Dependencies

--- a/src/cpp/r/ROptions.cpp
+++ b/src/cpp/r/ROptions.cpp
@@ -87,12 +87,27 @@ SEXP getOptionCell(const std::string& name)
       return R_NilValue;
    }
 
-   // keep reference to R options list
-   static SEXP optionsSEXP =
-         r::sexp::findVarInFrame(R_BaseNamespace, Rf_install(".Options"));
-
+   // Do not call R while holding a C++ static-initialization guard: an R
+   // longjmp would bypass its cleanup and leave subsequent reads blocked.
+   static SEXP optionsSEXP = nullptr;
    if (optionsSEXP == nullptr)
-      return R_NilValue;
+   {
+      SEXP resultSEXP = nullptr;
+      auto callback = +[](void* data) {
+         *static_cast<SEXP*>(data) =
+               r::sexp::findVarInFrame(R_BaseNamespace, Rf_install(".Options"));
+      };
+
+      // executeSafely() itself reads options before entering R_ToplevelExec,
+      // so use the R boundary directly here. Cache only a successful lookup.
+      if (!R_ToplevelExec(callback, &resultSEXP) ||
+          resultSEXP == nullptr || resultSEXP == R_NilValue)
+      {
+         return R_NilValue;
+      }
+
+      optionsSEXP = resultSEXP;
+   }
 
    // we search through the options list directly and return
    // the underlying value to avoid duplicating the underlying

--- a/src/cpp/r/RVersion.cpp
+++ b/src/cpp/r/RVersion.cpp
@@ -15,6 +15,8 @@
 
 #include <r/RVersion.hpp>
 
+#include <core/Thread.hpp>
+
 #include <r/RExec.hpp>
 
 using namespace rstudio::core;
@@ -27,14 +29,26 @@ static core::Version versionImpl()
    std::string version;
    Error error = r::exec::evaluateString("format(getRversion())", R_BaseEnv, &version);
    if (error)
+   {
       LOG_ERROR(error);
+      return Version();
+   }
 
    return Version(version);
 }
 
 core::Version version()
 {
-   static Version instance = versionImpl();
+   if (!ASSERT_MAIN_THREAD())
+      return Version();
+
+   // Finish C++ static initialization before evaluating R code, so an R
+   // longjmp cannot abandon the initialization guard. Failed lookups leave
+   // the cache empty and can be retried on the next call.
+   static Version instance;
+   if (instance.empty())
+      instance = versionImpl();
+
    return instance;
 }
 

--- a/src/cpp/session/modules/SessionRTests.cpp
+++ b/src/cpp/session/modules/SessionRTests.cpp
@@ -22,12 +22,15 @@
 #include <string>
 #include <thread>
 
+#include <core/Scope.hpp>
 #include <core/system/Environment.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RSexp.hpp>
 #include <r/RErrorCategory.hpp>
 #include <r/RInterface.hpp>
+#include <r/ROptions.hpp>
+#include <r/RVersion.hpp>
 #include <r/RUtil.hpp>
 
 using namespace rstudio::core;
@@ -35,6 +38,41 @@ using namespace rstudio::core;
 namespace rstudio {
 namespace session {
 namespace tests {
+
+TEST(SessionRTest, OptionCachePreservesCellsAcrossValueChanges) {
+   int originalWarn = r::options::getOption<int>("warn");
+   scope::CallOnExit restoreWarn([originalWarn]() {
+      r::options::setOption("warn", originalWarn);
+   });
+
+   SEXP cell = r::options::getOptionCell("warn");
+   ASSERT_NE(R_NilValue, cell);
+
+   // Consumers retain option cells to detect changes without duplicating
+   // R objects. Initializing the cache safely must preserve that behavior.
+   ASSERT_FALSE(r::options::setOption("warn", 1));
+   EXPECT_EQ(cell, r::options::getOptionCell("warn"));
+   EXPECT_EQ(1, r::options::getOption<int>("warn"));
+
+   ASSERT_FALSE(r::options::setOption("warn", 2));
+   EXPECT_EQ(cell, r::options::getOptionCell("warn"));
+   EXPECT_EQ(2, r::options::getOption<int>("warn"));
+}
+
+TEST(SessionRTest, VersionCacheOnlyUsesMainThread) {
+   std::string expected;
+   ASSERT_FALSE(r::exec::evaluateString("format(getRversion())", R_BaseEnv, &expected));
+   EXPECT_EQ(expected, static_cast<std::string>(r::version()));
+
+   // The cache is now populated explicitly outside its static initializer;
+   // workers must not access it, even after it has been populated.
+   Version workerVersion;
+   std::thread([&workerVersion]() {
+      workerVersion = r::version();
+   }).join();
+   EXPECT_TRUE(workerVersion.empty());
+   EXPECT_EQ(expected, static_cast<std::string>(r::version()));
+}
 
 TEST(SessionRTest, RFunctionErrorsDontSetResultToNull) {
    SEXP result = R_NilValue;


### PR DESCRIPTION
### Intent

Prepare candidate hardening for the startup hang reported in #18718. An R error that jumps out of a function-local C++ static initializer can bypass guard cleanup and block subsequent calls indefinitely. The options and version caches are two candidates on the console startup path.

This is speculative: the reported Linux hang has not been reproduced locally, and the stripped stack does not identify the blocked static. Keep this PR in draft until an affected workspace can test it or the core can be symbolized. Related to #18718; this does not establish that the issue is fixed.

### Approach

- Constant-initialize the options cache pointer, perform its first lookup inside a direct `R_ToplevelExec` callback, and cache only a successful non-null, non-nil result. Using `executeSafely()` here would recurse into option lookup while constructing its error-handler scope.
- Default-construct the version cache before evaluating R code, and populate it afterward on the main thread. Evaluation errors return an empty version so the next call can retry instead of caching a failed lookup.
- Preserve the existing option-cell identity and successful lookup caching. Add a NEWS entry describing the hardening.

### Automated Tests

Added session C++ tests for option-cell identity and value updates, plus runtime version retrieval and rejection of worker-thread cache access. These cover behavior around the changes; they do not inject a first-initialization R longjmp or reproduce the reported deadlock.

Validation on Windows with MSVC 19.51 and R 4.5.3:

- `cmake --build build --target rsession --parallel 8`: passed.
- `GTEST_FILTER=SessionRTest.*` via `rstudio-tests.bat --scope rsession`, with an isolated R profile and RStudio state: both new tests and three existing tests passed. Two existing tests failed: `SysGetenvSeesCoreSetenv` and `SynchronizeLocaleRepairsAClobberedLocale`.
- Rebuilt the same target with the three changed C++ files restored to unmodified `main` (`878a1fa2441`) and reran the suite: the same two existing tests failed with the same environment/locale mismatches (three passed). These failures are also present without this patch.
- `git diff --check`: passed.

The full unit suite and Linux startup reproduction have not been run.

### QA Notes

Test a build containing this patch on the affected Ubuntu container with its normal startup state. Check repeated fresh session starts and session restarts, whether `client_init` completes, and whether the console becomes usable. Also check ordinary startup and restored sessions in an unaffected environment.

If the hang persists, capture the exact executable and a core with executable mappings and matching symbols, then identify the frame calling `__cxa_guard_acquire`. Other static initializers are outside this patch's scope. The main remaining uncertainty is whether either changed cache is the guard in the original report.

### Documentation

NEWS entry only; no user-facing configuration or UI changes.

### Checklist

- [x] NEWS entry included.
- [ ] Reporter validation on the affected Linux environment.
- [ ] Reviewer assigned.
- [ ] Full local unit suite passes (focused results and baseline failures documented above).
