### PR TITLE
fix startup hang when an r error escapes deferred session initialization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 -
 
 ### Fixed
--
+- ([#18718](https://github.com/rstudio/rstudio/issues/18718)): Fixed an issue where an R error during session initialization could leave the session hung forever at startup, with RStudio Server reporting that R was taking longer than usual to start.
 
 ### Dependencies
 -

--- a/src/cpp/r/R/GlobalCallingHandlers.R
+++ b/src/cpp/r/R/GlobalCallingHandlers.R
@@ -30,30 +30,53 @@
 ))
 
 
-.rs.addFunction("globalCallingHandlers.initialize", function()
+.rs.addFunction("globalCallingHandlers.handlers", function()
 {
-   # Install our handlers.
-   if (.rs.uiPrefs$consoleHighlightConditions$get() == "errors_warnings_messages")
+   pref <- .rs.uiPrefs$consoleHighlightConditions$get()
+   if (identical(pref, "errors_warnings_messages"))
    {
-      globalCallingHandlers(
+      list(
          error   = .rs.globalCallingHandlers.onError,
          warning = .rs.globalCallingHandlers.onWarning,
          message = .rs.globalCallingHandlers.onMessage
       )
    }
-   else if (.rs.uiPrefs$consoleHighlightConditions$get() == "errors_warnings")
+   else if (identical(pref, "errors_warnings"))
    {
-      globalCallingHandlers(
+      list(
          error   = .rs.globalCallingHandlers.onError,
          warning = .rs.globalCallingHandlers.onWarning
       )
    }
-   else if (.rs.uiPrefs$consoleHighlightConditions$get() == "errors")
+   else if (identical(pref, "errors"))
    {
-      globalCallingHandlers(
+      list(
          error   = .rs.globalCallingHandlers.onError
       )
    }
+   else
+   {
+      list()
+   }
+})
+
+.rs.addFunction("globalCallingHandlers.initialize", function()
+{
+   # NOTE: The body of this function is evaluated directly at the top level
+   # (see installGlobalCallingHandlers() in SessionInit.cpp), as global calling
+   # handlers must attach to R's top-level context. An error raised here would
+   # escape as a longjmp through the C++ frames of session initialization, so
+   # everything that might fail is resolved inside tryCatch() first; only
+   # globalCallingHandlers() itself runs outside of it, since it refuses to run
+   # with condition handlers on the stack. As the body runs in the global
+   # environment, it must also not create any bindings.
+   do.call(
+      globalCallingHandlers,
+      tryCatch(
+         .rs.globalCallingHandlers.handlers(),
+         error = function(cnd) list()
+      )
+   )
 })
 
 .rs.addFunction("globalCallingHandlers.initializeCall", function()

--- a/src/cpp/r/R/GlobalCallingHandlers.R
+++ b/src/cpp/r/R/GlobalCallingHandlers.R
@@ -66,15 +66,28 @@
    # (see installGlobalCallingHandlers() in SessionInit.cpp), as global calling
    # handlers must attach to R's top-level context. An error raised here would
    # escape as a longjmp through the C++ frames of session initialization, so
-   # everything that might fail is resolved inside tryCatch() first; only
-   # globalCallingHandlers() itself runs outside of it, since it refuses to run
-   # with condition handlers on the stack. As the body runs in the global
-   # environment, it must also not create any bindings.
-   do.call(
-      globalCallingHandlers,
-      tryCatch(
+   # resolve handlers inside tryCatch() first. Registration itself must run
+   # outside of it, since globalCallingHandlers() refuses to run with local
+   # condition handlers on the stack. It can still fail if a caller installed
+   # handlers, so the C++ side does this last, after deferred initialization.
+   # As the body runs in the restored global environment, it must not create
+   # bindings or rely on unqualified base functions that the workspace can mask.
+   base::do.call(
+      base::globalCallingHandlers,
+      base::tryCatch(
          .rs.globalCallingHandlers.handlers(),
-         error = function(cnd) list()
+         error = function(cnd)
+         {
+            # Reporting the failure must not let another error escape.
+            base::tryCatch(
+               .rs.logWarningMessage(
+                  "Failed to initialize global calling handlers: %s",
+                  base::conditionMessage(cnd)
+               ),
+               error = function(cnd) NULL
+            )
+            base::list()
+         }
       )
    )
 })

--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -16,6 +16,8 @@
 #define R_INTERNAL_FUNCTIONS
 #include <r/RExec.hpp>
 
+#include <boost/scoped_ptr.hpp>
+
 #include <shared_core/FilePath.hpp>
 
 #include <core/Log.hpp>
@@ -284,7 +286,8 @@ bool isExecuting()
    return s_executionCount > 0;
 }
 
-Error executeSafely(boost::function<void()> function)
+Error executeSafely(boost::function<void()> function,
+                    ExecuteSafelyOptions options)
 {
    if (!ASSERT_MAIN_THREAD())
    {
@@ -293,8 +296,12 @@ Error executeSafely(boost::function<void()> function)
                ERROR_LOCATION);
    }
    
-   // disable custom error handlers while we execute code
-   DisableErrorHandlerScope disableErrorHandler;
+   // disable custom error handlers while we execute code (unless the
+   // caller needs them left in place)
+   boost::scoped_ptr<DisableErrorHandlerScope> disableErrorHandler;
+   if ((options & ExecuteSafelyKeepErrorHandler) == 0)
+      disableErrorHandler.reset(new DisableErrorHandlerScope());
+
    DisableDebugScope disableStepInto(R_GlobalEnv);
    
    // note that we're executing code in this scope

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -47,8 +47,20 @@ namespace rstudio {
 namespace r {
 namespace exec {
 
+// options for executeSafely
+enum ExecuteSafelyOptions
+{
+   ExecuteSafelyDefault          = 0,
+
+   // leave the user's error handler (options("error")) in place while the
+   // function runs, for code which needs to observe it; by default it is
+   // disabled so that e.g. recover() cannot be entered from internal code
+   ExecuteSafelyKeepErrorHandler = 1
+};
+
 // safe (no r error longjump) execution of arbitrary nullary function
-core::Error executeSafely(boost::function<void()> function);
+core::Error executeSafely(boost::function<void()> function,
+                          ExecuteSafelyOptions options = ExecuteSafelyDefault);
 
 typedef boost::function<bool()> MainThreadFunction;
 

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -400,8 +400,15 @@ void ensureDeserialized()
 {
    if (s_deferredDeserializationAction)
    {
-      // do the deferred action
-      s_deferredDeserializationAction();
+      // do the deferred action, containing any R error it raises so that it
+      // cannot longjmp through the C++ frames of session initialization
+      // (#18718). the action is cleared either way, as it must not run twice
+      Error error = r::exec::executeSafely(
+               s_deferredDeserializationAction,
+               r::exec::ExecuteSafelyKeepErrorHandler);
+      if (error)
+         LOG_ERROR(error);
+
       s_deferredDeserializationAction.clear();
    }
 

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -402,7 +402,8 @@ void ensureDeserialized()
    {
       // do the deferred action, containing any R error it raises so that it
       // cannot longjmp through the C++ frames of session initialization
-      // (#18718). the action is cleared either way, as it must not run twice
+      // (#18718). clear the action after either result so subsequent calls
+      // do not retry a restore that may already have partially completed
       Error error = r::exec::executeSafely(
                s_deferredDeserializationAction,
                r::exec::ExecuteSafelyKeepErrorHandler);

--- a/src/cpp/session/SessionInit.cpp
+++ b/src/cpp/session/SessionInit.cpp
@@ -59,17 +59,14 @@ void installGlobalCallingHandlers()
    // this must be evaluated directly rather than via R_tryEval(): global
    // calling handlers attach to R's top-level context, and would be discarded
    // along with the temporary context established by R_ToplevelExec(). an R
-   // error raised here therefore escapes as a longjmp, so the R side resolves
-   // everything that might fail before it calls globalCallingHandlers()
+   // error raised here therefore escapes as a longjmp. the R side contains
+   // errors while resolving handlers, but registration itself can still fail
+   // (e.g. if a caller has condition handlers on the stack)
    Rf_eval(initializeSEXP, R_GlobalEnv);
 }
 
 void ensureSessionInitializedImpl()
 {
-   // install condition handlers if requested
-   if (r::session::utils::isR4())
-      installGlobalCallingHandlers();
-
    // note that we are now fully initialized. we defer setting this
    // flag so that consoleRead and handleClientInit know that we have just
    // started up and can act accordingly
@@ -79,6 +76,12 @@ void ensureSessionInitializedImpl()
    // is supported so that the workbench UI can load without having to wait
    // for the potentially very lengthy deserialization of the environment)
    rstudio::r::session::ensureDeserialized();
+
+   // install condition handlers last: the raw R evaluation can still longjmp,
+   // and must not prevent deserialization or leave s_sessionInitialized false
+   // after the one-time initialization flag has been set
+   if (r::session::utils::isR4())
+      installGlobalCallingHandlers();
 }
 
 } // anonymous namespace

--- a/src/cpp/session/SessionInit.cpp
+++ b/src/cpp/session/SessionInit.cpp
@@ -40,23 +40,35 @@ std::atomic<bool> s_sessionInitialized(false);
 // completed) from a fresh start or suspend/resume (event still to fire)
 std::atomic<bool> s_deferredInitCompleted(false);
 
-} // anonymous namespace
+// has ensureSessionInitialized() run? (main thread only.) this is an
+// explicit flag, set before the one-time work begins, rather than a
+// function-local static: an R error escaping that work longjmps over the
+// static's initialization guard and leaves it locked for good, so the next
+// client_init blocks forever in __cxa_guard_acquire (#18718)
+bool s_ensureSessionInitializedCalled = false;
 
-bool ensureSessionInitializedImpl()
+void installGlobalCallingHandlers()
+{
+   SEXP initializeSEXP = R_NilValue;
+   r::sexp::Protect protect;
+   Error error = r::exec::RFunction(".rs.globalCallingHandlers.initializeCall")
+         .call(&initializeSEXP, &protect);
+   if (error)
+      LOG_ERROR(error);
+
+   // this must be evaluated directly rather than via R_tryEval(): global
+   // calling handlers attach to R's top-level context, and would be discarded
+   // along with the temporary context established by R_ToplevelExec(). an R
+   // error raised here therefore escapes as a longjmp, so the R side resolves
+   // everything that might fail before it calls globalCallingHandlers()
+   Rf_eval(initializeSEXP, R_GlobalEnv);
+}
+
+void ensureSessionInitializedImpl()
 {
    // install condition handlers if requested
    if (r::session::utils::isR4())
-   {
-      // install global calling handlers
-      SEXP initializeSEXP = R_NilValue;
-      r::sexp::Protect protect;
-      Error error = r::exec::RFunction(".rs.globalCallingHandlers.initializeCall")
-            .call(&initializeSEXP, &protect);
-      if (error)
-         LOG_ERROR(error);
-
-      Rf_eval(initializeSEXP, R_GlobalEnv);
-   }
+      installGlobalCallingHandlers();
 
    // note that we are now fully initialized. we defer setting this
    // flag so that consoleRead and handleClientInit know that we have just
@@ -67,17 +79,19 @@ bool ensureSessionInitializedImpl()
    // is supported so that the workbench UI can load without having to wait
    // for the potentially very lengthy deserialization of the environment)
    rstudio::r::session::ensureDeserialized();
-
-   return true;
-
 }
+
+} // anonymous namespace
 
 // certain things are deferred until after we have sent our first response
 // take care of these things here
 void ensureSessionInitialized()
 {
-   static bool once = ensureSessionInitializedImpl();
-   (void) once;
+   if (s_ensureSessionInitializedCalled)
+      return;
+
+   s_ensureSessionInitializedCalled = true;
+   ensureSessionInitializedImpl();
 }
 
 bool isSessionInitialized()

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1011,7 +1011,18 @@ void rSessionInitHook(bool newSession)
 
 void rDeferredInit(bool newSession)
 {
-   module_context::events().onDeferredInit(newSession);
+   // run the deferred init handlers with any R error they raise contained
+   // here, rather than letting it longjmp through the C++ frames of session
+   // initialization (#18718). the user's error handler is left in place, as
+   // some handlers inspect it (see SessionErrors)
+   Error error = rstudio::r::exec::executeSafely(
+            [&]()
+            {
+               module_context::events().onDeferredInit(newSession);
+            },
+            rstudio::r::exec::ExecuteSafelyKeepErrorHandler);
+   if (error)
+      LOG_ERROR(error);
 
    // schedule execution of the session init hook
    module_context::scheduleDelayedWork(

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1022,7 +1022,12 @@ void rDeferredInit(bool newSession)
             },
             rstudio::r::exec::ExecuteSafelyKeepErrorHandler);
    if (error)
+   {
+      error.addProperty("description",
+                        "Deferred initialization failed; remaining handlers were skipped");
+      error.addProperty("newSession", newSession);
       LOG_ERROR(error);
+   }
 
    // schedule execution of the session init hook
    module_context::scheduleDelayedWork(

--- a/src/cpp/tests/testthat/resources/global-calling-handlers.R
+++ b/src/cpp/tests/testthat/resources/global-calling-handlers.R
@@ -1,0 +1,127 @@
+# Standalone subprocess for test-global-calling-handlers.R. Do not source this
+# under testthat: registration requires no local condition handlers on the stack.
+
+definitions <- readRDS(commandArgs(trailingOnly = TRUE)[[1L]])
+rsEnv <- new.env(parent = baseenv())
+for (name in names(definitions))
+{
+   assign(paste0(".rs.globalCallingHandlers.", name),
+          eval(call("function", pairlist(), definitions[[name]]), rsEnv), rsEnv)
+}
+
+# Keep the production bodies and stub only the preference, logging, and
+# embedding callbacks. Their lexical environment stays separate from .GlobalEnv,
+# as it does for functions in tools:rstudio.
+rsEnv$preference <- "none"
+rsEnv$preferenceFailure <- FALSE
+rsEnv$loggingFailure <- FALSE
+rsEnv$diagnostics <- character()
+rsEnv$.rs.uiPrefs <- list(consoleHighlightConditions = list(get = eval(quote(function()
+{
+   if (preferenceFailure)
+      stop("broken preference")
+   preference
+}), rsEnv)))
+rsEnv$.rs.logWarningMessage <- eval(quote(function(fmt, ...)
+{
+   if (loggingFailure)
+      stop("broken logger")
+   diagnostics <<- c(diagnostics, sprintf(fmt, ...))
+}), rsEnv)
+for (kind in c("Error", "Warning", "Message"))
+   assign(paste0(".rs.globalCallingHandlers.on", kind),
+          eval(quote(function(cnd) NULL), rsEnv), rsEnv)
+attach(rsEnv, name = "tools:rstudio")
+initializer <- body(rsEnv$.rs.globalCallingHandlers.initialize)
+
+checkInitialization <- function(label, expected = NULL, diagnostic = NULL,
+                                checkSelection = TRUE)
+{
+   base::globalCallingHandlers(NULL)
+   rsEnv$diagnostics <- character()
+   if (checkSelection)
+      stopifnot(identical(names(rsEnv$.rs.globalCallingHandlers.handlers()), expected))
+
+   before <- ls(.GlobalEnv, all.names = TRUE)
+   eval(initializer, .GlobalEnv)
+   stopifnot(identical(before, ls(.GlobalEnv, all.names = TRUE)))
+   installed <- base::globalCallingHandlers()
+   stopifnot(identical(names(installed), expected))
+   for (kind in expected)
+   {
+      suffix <- switch(kind, error = "Error", warning = "Warning", message = "Message")
+      stopifnot(identical(installed[[kind]],
+                          get(paste0(".rs.globalCallingHandlers.on", suffix), rsEnv)))
+   }
+
+   if (is.null(diagnostic))
+      stopifnot(length(rsEnv$diagnostics) == 0L)
+   else
+   {
+      stopifnot(length(rsEnv$diagnostics) == 1L,
+                grepl("Failed to initialize global calling handlers:",
+                      rsEnv$diagnostics, fixed = TRUE),
+                grepl(diagnostic, rsEnv$diagnostics, fixed = TRUE))
+   }
+   base::globalCallingHandlers(NULL)
+   cat("PASS:", label, "\n")
+}
+
+for (preference in c("errors", "errors_warnings", "errors_warnings_messages", "none"))
+{
+   rsEnv$preference <- preference
+   expected <- switch(preference,
+                      errors = "error",
+                      errors_warnings = c("error", "warning"),
+                      errors_warnings_messages = c("error", "warning", "message"),
+                      none = NULL)
+   checkInitialization(preference, expected)
+}
+
+invalidPreferences <- list(NULL, "unknown", NA_character_, character(),
+                           c("errors", "errors_warnings"), 1L, list())
+for (preference in invalidPreferences)
+{
+   rsEnv$preference <- preference
+   checkInitialization(paste("invalid preference", paste(deparse(preference), collapse = " ")))
+}
+
+rsEnv$preferenceFailure <- TRUE
+checkInitialization("throwing getter", diagnostic = "broken preference", checkSelection = FALSE)
+rsEnv$loggingFailure <- TRUE
+checkInitialization("throwing logger", checkSelection = FALSE)
+rsEnv$loggingFailure <- FALSE
+rsEnv$preferenceFailure <- FALSE
+
+preferences <- rsEnv$.rs.uiPrefs
+rm(".rs.uiPrefs", envir = rsEnv)
+checkInitialization("missing preferences", diagnostic = ".rs.uiPrefs", checkSelection = FALSE)
+rsEnv$.rs.uiPrefs <- preferences
+
+rsEnv$preference <- "errors"
+errorHandler <- rsEnv$.rs.globalCallingHandlers.onError
+rm(".rs.globalCallingHandlers.onError", envir = rsEnv)
+checkInitialization("missing handler", diagnostic = ".rs.globalCallingHandlers.onError",
+                    checkSelection = FALSE)
+rsEnv$.rs.globalCallingHandlers.onError <- errorHandler
+
+# Installation now happens after workspace restore. User functions with these
+# names must not intercept either registration or its error-reporting path.
+maskedNames <- c("do.call", "globalCallingHandlers", "tryCatch", "conditionMessage", "list")
+for (name in maskedNames)
+   assign(name, function(...) stop("masked base function called"), .GlobalEnv)
+checkInitialization("masked base functions", "error")
+rsEnv$preferenceFailure <- TRUE
+checkInitialization("masked base functions during failure", diagnostic = "broken preference",
+                    checkSelection = FALSE)
+rm(list = maskedNames, envir = .GlobalEnv)
+rsEnv$preferenceFailure <- FALSE
+
+# Falling back to no RStudio handlers must preserve handlers installed by others.
+base::globalCallingHandlers(custom = function(cnd) NULL)
+existing <- base::globalCallingHandlers()
+rsEnv$preference <- NULL
+invisible(eval(initializer, .GlobalEnv))
+stopifnot(identical(base::globalCallingHandlers(), existing))
+base::globalCallingHandlers(NULL)
+cat("PASS: existing handlers preserved\n")

--- a/src/cpp/tests/testthat/test-global-calling-handlers.R
+++ b/src/cpp/tests/testthat/test-global-calling-handlers.R
@@ -1,0 +1,45 @@
+#
+# test-global-calling-handlers.R
+#
+# Copyright (C) 2026 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("global calling handlers")
+
+test_that("global calling handlers initialize safely at the top level", {
+   skip_if(getRversion() < "4.0.0")
+
+   # testthat installs condition handlers, which prevent globalCallingHandlers()
+   # from registering handlers. Run the actual initializer in a vanilla Rscript
+   # process, passing its body and the handler-selection body from this session.
+   # Serialize only the bodies so no session environments reach the subprocess.
+   definitions <- tempfile(fileext = ".rds")
+   on.exit(unlink(definitions), add = TRUE)
+   saveRDS(list(
+      handlers = body(.rs.globalCallingHandlers.handlers),
+      initialize = body(.rs.globalCallingHandlers.initialize)
+   ), definitions)
+
+   rscript <- file.path(R.home("bin"),
+                       if (.Platform$OS.type == "windows") "Rscript.exe" else "Rscript")
+   output <- suppressWarnings(system2(
+      rscript,
+      c("--vanilla", shQuote("resources/global-calling-handlers.R"),
+        shQuote(definitions)),
+      stdout = TRUE,
+      stderr = TRUE
+   ))
+   status <- attr(output, "status")
+   if (is.null(status))
+      status <- 0L
+   expect_equal(status, 0L, info = paste(output, collapse = "\n"))
+})


### PR DESCRIPTION
Addresses #18718.

## Root cause

The reporter's core dump shows the rsession main thread parked forever in `__cxa_guard_acquire`, five (stripped) rsession frames below `Rf_ReplIteration`, with no other thread holding the guard. Resolving those frames against the shipped `2025.09.2+418` binary (ASLR keeps page offsets and inter-frame deltas, so the five return addresses match exactly one call chain in the binary) gives:

```
#1  __cxa_guard_acquire
#2  session::init::ensureSessionInitialized()        (SessionInit.cpp)
#3  session::client_init::handleClientInit()
#4  session::http_methods::waitForMethod()
#5  session::console_input::rConsoleRead()
#6  r::session::RReadConsole()
#7  Rf_ReplIteration
```

`ensureSessionInitialized()` ran its one-time work as the initializer of a function-local static:

```cpp
static bool once = ensureSessionInitializedImpl();
```

That initializer is the whole deferred-init corridor: the raw `Rf_eval()` that installs the global calling handlers, the workspace / suspended-session restore, and every module's `onDeferredInit` handler. If an R error (or interrupt) escapes any of that, R longjmps back to the REPL top level straight over the initializer's frame, so `__cxa_guard_release` / `__cxa_guard_abort` never run and the guard stays in its "initialization in progress" state. The remaining initialization work is abandoned, and the client's next `client_init` re-enters `ensureSessionInitialized()` and blocks on the futex forever. Reload / Terminate R reproduce it because the state that raised the error is still there; Safe Mode skips most of the corridor.

## Fix

- `SessionInit.cpp`: replace the guarded static with an explicit flag set before the one-time work begins. Install global calling handlers after setting `s_sessionInitialized` and completing `ensureDeserialized()`, so a failure during registration cannot permanently skip that work. Keep the registration's raw `Rf_eval()` outside `R_ToplevelExec`: the handlers must attach to the real top-level context.
- `GlobalCallingHandlers.R`: select handlers using exact preference comparisons, with malformed or unknown values selecting none. Contain preference lookup and handler resolution errors in `tryCatch()` and log their conditions; protect the logging call against errors too. Qualify the initializer's base R functions because its body runs in the restored global environment, where workspace functions could mask them. The initializer creates no global bindings.
- `RInit.cpp`: run the deferred deserialization action under `R_ToplevelExec`, logging an escaping R error and clearing the action after either result so subsequent calls do not retry a partially completed restore.
- `SessionMain.cpp`: separately contain R errors around the `onDeferredInit` dispatch, then schedule the session init hook. The error log records `newSession` and explains that remaining deferred-init handlers were skipped.
- `RExec.hpp/.cpp`: add `ExecuteSafelyKeepErrorHandler` for the two containment boundaries, since `SessionErrors` inspects `options("error")` from its deferred-init handler and the default `executeSafely()` temporarily clears it.

Registration itself can still fail, for example when an outer caller has local condition handlers on the stack, or when an interrupt arrives. Doing it last protects the preceding initialization work; it does not contain that remaining longjmp. Likewise, `R_ToplevelExec` does not run C++ destructors for frames inside its callback. The inner deferred-init boundary lets `completeDeferredSessionInit()` return normally and destroy its `SuppressOutputInScope`; the outer boundary does not provide a general unwinding guarantee for scopes inside restoration. Per-handler recovery and reentrant restoration remain separate concerns.

A sweep of the other function-local statics with call initializers in `session/` and `r/` found no other one that runs R code which can longjmp on the startup path; `r::sexp::findFunction()`'s raw promise forcing (used by `knownNseFunctions`) is the one remaining theoretical case, left alone because wrapping it would perturb the R context stack it is inspecting.

## Verification

- No local reproducer for the reporter's original environment-specific hang; the diagnosis is based on the frame match above and the initialization control flow.
- C++ syntax-only checks passed for the updated `SessionInit.cpp` and `SessionMain.cpp` using the configured build's compiler flags and the PR worktree's headers.
- Committed `test-global-calling-handlers.R` invokes a vanilla Rscript subprocess using the production function bodies. The subprocess is required because testthat itself installs local condition handlers. All 18 scenarios passed on R 4.6.1: supported preference values, malformed values, throwing getters and loggers, missing preferences and handlers, masked base functions, and preservation of existing handlers. The harness checks handler selection, actual registration, diagnostics, and absence of new global bindings.
- The regression harness rejects the previous initializer because it silently discards preference lookup errors.
