### PR TITLE
Fix two e2e test bugs and report why an RStudio launch failed

### DIFF
--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -729,7 +729,10 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
   let lastConnectErr: unknown;
   while (Date.now() < cdpDeadline) {
     if (launchError) {
-      const state = describeLaunchState(rstudioProcess, outputTail?.(), cdpPortListenerPids());
+      // The child has exited by now; give its streams a moment to deliver the
+      // trailing output, which is the part that says why it died.
+      await outputTail?.settled();
+      const state = describeLaunchState(rstudioProcess, outputTail?.text(), cdpPortListenerPids());
       killProcessTree(rstudioProcess);
       throw new Error(`${launchError.message}\n${state}`);
     }
@@ -742,7 +745,8 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
     }
   }
   if (!browser) {
-    const state = describeLaunchState(rstudioProcess, outputTail?.(), cdpPortListenerPids());
+    await outputTail?.settled();
+    const state = describeLaunchState(rstudioProcess, outputTail?.text(), cdpPortListenerPids());
     killProcessTree(rstudioProcess);
     throw new Error(
       `Failed to connect to CDP at ${CDP_URL} within ${startupTimeout}ms: ${(lastConnectErr as Error)?.message ?? 'unknown'}\n${state}`,

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -12,6 +12,7 @@ import { dismissAllModals, documentCloseAllNoSave, executeCommand } from '../uti
 import { withDeadline } from '../utils/deadline';
 import { workerRLibsUser } from './r-libs-setup';
 import { trackForReaping } from './process-reaper';
+import { captureOutputTail, describeLaunchState } from './launch-diagnostics';
 import { isDebugMode } from '../utils/debug';
 import { userHomeForAuthState } from '../utils/auth';
 
@@ -689,20 +690,29 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
   // tree is detached into its own group and would otherwise survive the run.
   trackForReaping(rstudioProcess, () => killProcessTree(rstudioProcess));
   const launchTarget = DEV_MODE ? `npm run start (cwd ${DEV_DESKTOP_DIR})` : RSTUDIO_PATH;
+  // Dev mode inherits the streams to the terminal, so there is nothing to
+  // read; every other path pipes them and would otherwise discard them.
+  const outputTail = DEV_MODE ? undefined : captureOutputTail(rstudioProcess);
   let launchError: Error | undefined;
+  let cdpConnected = false;
   rstudioProcess.on('error', (err) => {
     launchError = new Error(`Failed to launch RStudio (${launchTarget}): ${err.message}`);
   });
   // `'error'` only fires on spawn-level failures (ENOENT). An exit with a
   // non-zero code -- missing npm script, webpack abort, electron-forge
   // crash -- would otherwise sit unnoticed for the full CDP-wait timeout.
-  // We only treat code !== 0 as an error; code === null means the process
-  // was killed by signal (typically our own killProcessTree during
-  // teardown), which isn't a launch failure.
+  // A signal death (code === null) is usually our own killProcessTree, but
+  // that only runs after we have already decided to fail -- so before CDP is
+  // up the signal came from outside (OOM killer, segfault), which is exactly
+  // the launch failure rstudio#18522 could never account for.
   rstudioProcess.on('exit', (code, signal) => {
     if (code !== null && code !== 0) {
       launchError = new Error(
         `RStudio process (${launchTarget}) exited prematurely with code ${code}${signal ? ` (signal ${signal})` : ''}`,
+      );
+    } else if (code === null && signal && !cdpConnected) {
+      launchError = new Error(
+        `RStudio process (${launchTarget}) was killed by ${signal} before CDP became reachable`,
       );
     }
   });
@@ -719,8 +729,9 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
   let lastConnectErr: unknown;
   while (Date.now() < cdpDeadline) {
     if (launchError) {
+      const state = describeLaunchState(rstudioProcess, outputTail?.(), cdpPortListenerPids());
       killProcessTree(rstudioProcess);
-      throw launchError;
+      throw new Error(`${launchError.message}\n${state}`);
     }
     try {
       browser = await chromium.connectOverCDP(CDP_URL, { timeout: 5000 });
@@ -731,11 +742,13 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
     }
   }
   if (!browser) {
+    const state = describeLaunchState(rstudioProcess, outputTail?.(), cdpPortListenerPids());
     killProcessTree(rstudioProcess);
     throw new Error(
-      `Failed to connect to CDP at ${CDP_URL} within ${startupTimeout}ms: ${(lastConnectErr as Error)?.message ?? 'unknown'}`,
+      `Failed to connect to CDP at ${CDP_URL} within ${startupTimeout}ms: ${(lastConnectErr as Error)?.message ?? 'unknown'}\n${state}`,
     );
   }
+  cdpConnected = true;
 
   attachLaunchDebug(browser);
 

--- a/e2e/rstudio/fixtures/launch-diagnostics.ts
+++ b/e2e/rstudio/fixtures/launch-diagnostics.ts
@@ -42,7 +42,7 @@ export interface OutputTail {
  * launch that dies says so at the end.
  */
 export function captureOutputTail(
-  proc: ChildProcess,
+  proc: Pick<ChildProcess, 'stdout' | 'stderr' | 'exitCode' | 'signalCode'>,
   limit: number = OUTPUT_TAIL_LIMIT,
 ): OutputTail {
   let tail = '';

--- a/e2e/rstudio/fixtures/launch-diagnostics.ts
+++ b/e2e/rstudio/fixtures/launch-diagnostics.ts
@@ -1,0 +1,76 @@
+import type { ChildProcess } from 'child_process';
+
+/**
+ * Diagnostics for an RStudio Desktop launch that never became reachable over
+ * CDP.
+ *
+ * A bare `ECONNREFUSED` after the startup timeout cannot tell an Electron
+ * that died from one that is alive but never bound the port. That ambiguity
+ * is why the repeated launch failures in rstudio#18522 stayed unexplained:
+ * the fixture spawned a process, waited out the timeout, and reported
+ * nothing about what the process actually did.
+ */
+
+/** Cap on retained child output -- enough for a stack or a fatal error. */
+export const OUTPUT_TAIL_LIMIT = 4000;
+
+/**
+ * Drain a spawned child's stdout/stderr into a bounded tail and return a
+ * getter for it.
+ *
+ * Draining matters on its own: nothing reads these pipes otherwise, and a
+ * child blocks once a pipe buffer fills (~64KB on Linux), so a chatty
+ * startup could hang rather than fail. Only the tail is kept, since a
+ * launch that dies says so at the end.
+ */
+export function captureOutputTail(
+  proc: ChildProcess,
+  limit: number = OUTPUT_TAIL_LIMIT,
+): () => string {
+  let tail = '';
+  const append = (chunk: Buffer | string): void => {
+    tail = (tail + chunk.toString()).slice(-limit);
+  };
+  proc.stdout?.on('data', append);
+  proc.stderr?.on('data', append);
+  return () => tail;
+}
+
+/**
+ * Describe how the child and the CDP port looked when the launch gave up.
+ *
+ * `outputTail` is `undefined` when output was never captured (dev mode
+ * inherits the streams). That reads differently from a child that ran and
+ * wrote nothing, which is itself a signal worth seeing.
+ */
+export function describeLaunchState(
+  proc: Pick<ChildProcess, 'pid' | 'exitCode' | 'signalCode'>,
+  outputTail: string | undefined,
+  portHolders: string,
+): string {
+  const parts: string[] = [];
+
+  if (proc.exitCode !== null) {
+    parts.push(`process exited with code ${proc.exitCode}`);
+  } else if (proc.signalCode !== null) {
+    parts.push(`process was killed by ${proc.signalCode}`);
+  } else {
+    parts.push(`process (PID ${proc.pid ?? 'unknown'}) was still running`);
+  }
+
+  parts.push(
+    portHolders
+      ? `CDP port LISTEN owner(s): ${portHolders}`
+      : 'nothing was listening on the CDP port',
+  );
+
+  const state = `[launch-state] ${parts.join('; ')}`;
+  if (outputTail === undefined) {
+    return `${state}; child output not captured (streams inherited)`;
+  }
+
+  const trimmed = outputTail.trim();
+  return trimmed
+    ? `${state}\n[launch-output] last ${trimmed.length} char(s) of stdout/stderr:\n${trimmed}`
+    : `${state}; the child wrote nothing to stdout/stderr`;
+}

--- a/e2e/rstudio/fixtures/launch-diagnostics.ts
+++ b/e2e/rstudio/fixtures/launch-diagnostics.ts
@@ -14,9 +14,27 @@ import type { ChildProcess } from 'child_process';
 /** Cap on retained child output -- enough for a stack or a fatal error. */
 export const OUTPUT_TAIL_LIMIT = 4000;
 
+/** Default wait for a dead child's streams to deliver their last reads. */
+export const TAIL_SETTLE_TIMEOUT_MS = 500;
+
+export interface OutputTail {
+  /** The captured tail as of now. */
+  text(): string;
+  /**
+   * Resolve once both streams have ended, or after `timeoutMs`.
+   *
+   * Node emits `'exit'` before the stdio streams necessarily deliver their
+   * final reads, so reading the tail straight off an exit can miss the
+   * trailing output -- which is exactly the part that says why the child
+   * died. Bounded because a stream that errors may never end, and resolves
+   * at once for a child that is still running (its streams stay open) or one
+   * whose streams already ended.
+   */
+  settled(timeoutMs?: number): Promise<void>;
+}
+
 /**
- * Drain a spawned child's stdout/stderr into a bounded tail and return a
- * getter for it.
+ * Drain a spawned child's stdout/stderr into a bounded tail.
  *
  * Draining matters on its own: nothing reads these pipes otherwise, and a
  * child blocks once a pipe buffer fills (~64KB on Linux), so a chatty
@@ -26,14 +44,38 @@ export const OUTPUT_TAIL_LIMIT = 4000;
 export function captureOutputTail(
   proc: ChildProcess,
   limit: number = OUTPUT_TAIL_LIMIT,
-): () => string {
+): OutputTail {
   let tail = '';
   const append = (chunk: Buffer | string): void => {
     tail = (tail + chunk.toString()).slice(-limit);
   };
-  proc.stdout?.on('data', append);
-  proc.stderr?.on('data', append);
-  return () => tail;
+
+  const streams = [proc.stdout, proc.stderr].filter((s): s is NonNullable<typeof s> => !!s);
+  let pending = streams.length;
+  let onDrained: (() => void) | undefined;
+  for (const stream of streams) {
+    stream.on('data', append);
+    stream.once('end', () => {
+      if (--pending === 0) onDrained?.();
+    });
+  }
+
+  return {
+    text: () => tail,
+    settled: (timeoutMs: number = TAIL_SETTLE_TIMEOUT_MS) =>
+      new Promise<void>((resolve) => {
+        const running = proc.exitCode === null && proc.signalCode === null;
+        if (pending === 0 || running) {
+          resolve();
+          return;
+        }
+        const timer = setTimeout(resolve, timeoutMs);
+        onDrained = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+      }),
+  };
 }
 
 /**

--- a/e2e/rstudio/tests/harness/launch-diagnostics.test.ts
+++ b/e2e/rstudio/tests/harness/launch-diagnostics.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { spawn, type ChildProcess } from 'child_process';
+import { PassThrough } from 'stream';
 import { captureOutputTail, describeLaunchState, OUTPUT_TAIL_LIMIT } from '@fixtures/launch-diagnostics';
 
 /**
@@ -97,6 +98,37 @@ test.describe('launch diagnostics', { tag: ['@desktop_only'] }, () => {
 
     const state = describeLaunchState(proc, captured, '');
     expect(state).toContain('FATAL-AT-THE-END');
+  });
+
+  test('settled() waits for data that arrives after the child has exited', async () => {
+    // The real race is not reproducible on demand: a spawned child that writes
+    // and exits had all output delivered before 'exit' at 12B, 8KB, 200KB and
+    // 2MB. Drive it deterministically instead, with streams we control and an
+    // already-set exitCode standing in for a child that has gone.
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const exited = { stdout, stderr, exitCode: 1, signalCode: null };
+
+    const tail = captureOutputTail(exited);
+    let done = false;
+    const settling = tail.settled(5000).then(() => {
+      done = true;
+    });
+
+    // Nothing has ended yet, so settled() must still be waiting -- this is the
+    // assertion that fails if it resolves eagerly off the exit code.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(done).toBe(false);
+    expect(tail.text()).toBe('');
+
+    stderr.write('FATAL-AFTER-EXIT');
+    stderr.end();
+    stdout.end();
+    await settling;
+
+    expect(done).toBe(true);
+    expect(tail.text()).toContain('FATAL-AFTER-EXIT');
+    expect(describeLaunchState(exited, tail.text(), '')).toContain('FATAL-AFTER-EXIT');
   });
 
   test('settled() does not stall the failure path for a live child', async () => {

--- a/e2e/rstudio/tests/harness/launch-diagnostics.test.ts
+++ b/e2e/rstudio/tests/harness/launch-diagnostics.test.ts
@@ -25,6 +25,11 @@ function waitForExit(proc: ChildProcess): Promise<void> {
   return new Promise((resolve) => proc.once('exit', () => resolve()));
 }
 
+/** Let already-resolved promise callbacks run before asserting on them. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 test.describe('launch diagnostics', { tag: ['@desktop_only'] }, () => {
   test('reports a live child as still running, not as a death', async () => {
     const proc = spawn(NODE, LINGER, { stdio: 'pipe' });
@@ -117,13 +122,24 @@ test.describe('launch diagnostics', { tag: ['@desktop_only'] }, () => {
 
     // Nothing has ended yet, so settled() must still be waiting -- this is the
     // assertion that fails if it resolves eagerly off the exit code.
-    await new Promise((resolve) => setImmediate(resolve));
+    await tick();
     expect(done).toBe(false);
     expect(tail.text()).toBe('');
 
+    // Bring one stream down on its own. settled() waits for *both*, so it must
+    // still be pending here; ending them together would hide a settled() that
+    // resolves on the first 'end'. Awaiting the event rather than a delay keeps
+    // this deterministic -- captureOutputTail's listener was attached first, so
+    // it has already processed the end by the time this resolves.
+    const stdoutEnded = new Promise((resolve) => stdout.once('end', resolve));
+    stdout.end();
+    await stdoutEnded;
+    await tick();
+    expect(done).toBe(false);
+
+    // The fatal line arrives on the stream that is still open.
     stderr.write('FATAL-AFTER-EXIT');
     stderr.end();
-    stdout.end();
     await settling;
 
     expect(done).toBe(true);

--- a/e2e/rstudio/tests/harness/launch-diagnostics.test.ts
+++ b/e2e/rstudio/tests/harness/launch-diagnostics.test.ts
@@ -24,12 +24,6 @@ function waitForExit(proc: ChildProcess): Promise<void> {
   return new Promise((resolve) => proc.once('exit', () => resolve()));
 }
 
-// 'exit' can precede the final stdout/stderr reads; 'close' means the streams
-// are done, which is what the output assertions depend on.
-function waitForClose(proc: ChildProcess): Promise<void> {
-  return new Promise((resolve) => proc.once('close', () => resolve()));
-}
-
 test.describe('launch diagnostics', { tag: ['@desktop_only'] }, () => {
   test('reports a live child as still running, not as a death', async () => {
     const proc = spawn(NODE, LINGER, { stdio: 'pipe' });
@@ -94,14 +88,31 @@ test.describe('launch diagnostics', { tag: ['@desktop_only'] }, () => {
       { stdio: 'pipe' },
     );
     const tail = captureOutputTail(proc);
-    await waitForClose(proc);
+    await waitForExit(proc);
+    await tail.settled();
 
-    const captured = tail();
+    const captured = tail.text();
     expect(captured).toHaveLength(OUTPUT_TAIL_LIMIT);
     expect(captured).toContain('FATAL-AT-THE-END');
 
     const state = describeLaunchState(proc, captured, '');
     expect(state).toContain('FATAL-AT-THE-END');
+  });
+
+  test('settled() does not stall the failure path for a live child', async () => {
+    // A running child's streams stay open, so waiting on them would burn the
+    // whole bounded timeout on every CDP-timeout failure. settled() has to
+    // short-circuit instead.
+    const proc = spawn(NODE, LINGER, { stdio: 'pipe' });
+    const tail = captureOutputTail(proc);
+    try {
+      const started = Date.now();
+      await tail.settled(5000);
+      expect(Date.now() - started).toBeLessThan(1000);
+    } finally {
+      proc.kill('SIGKILL');
+      await waitForExit(proc);
+    }
   });
 
   test('distinguishes uncaptured output from a child that wrote nothing', async () => {

--- a/e2e/rstudio/tests/harness/launch-diagnostics.test.ts
+++ b/e2e/rstudio/tests/harness/launch-diagnostics.test.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test';
+import { spawn, type ChildProcess } from 'child_process';
+import { captureOutputTail, describeLaunchState, OUTPUT_TAIL_LIMIT } from '@fixtures/launch-diagnostics';
+
+/**
+ * Harness self-test for the launch diagnostics in fixtures/desktop.fixture.ts
+ * (rstudio#18522).
+ *
+ * When RStudio stops becoming reachable over CDP, the fixture used to report
+ * only `ECONNREFUSED` after the startup timeout -- which cannot distinguish an
+ * Electron that died from one that is alive but never bound the port. These
+ * tests pin the three states apart, and pin that child output survives to be
+ * reported, using real child processes rather than the RStudio binary.
+ *
+ * Deliberately imports plain `@playwright/test`: nothing here needs an IDE, so
+ * the suite must not pay a launch for it.
+ */
+
+const NODE = process.execPath;
+// Long enough to outlive the assertions; every test kills its own child.
+const LINGER = ['-e', 'setTimeout(() => {}, 60000)'];
+
+function waitForExit(proc: ChildProcess): Promise<void> {
+  return new Promise((resolve) => proc.once('exit', () => resolve()));
+}
+
+// 'exit' can precede the final stdout/stderr reads; 'close' means the streams
+// are done, which is what the output assertions depend on.
+function waitForClose(proc: ChildProcess): Promise<void> {
+  return new Promise((resolve) => proc.once('close', () => resolve()));
+}
+
+test.describe('launch diagnostics', { tag: ['@desktop_only'] }, () => {
+  test('reports a live child as still running, not as a death', async () => {
+    const proc = spawn(NODE, LINGER, { stdio: 'pipe' });
+    try {
+      const state = describeLaunchState(proc, '', '');
+      expect(state).toContain(`PID ${proc.pid}`);
+      expect(state).toContain('still running');
+      expect(state).not.toContain('exited with code');
+      expect(state).not.toContain('killed by');
+    } finally {
+      proc.kill('SIGKILL');
+      await waitForExit(proc);
+    }
+  });
+
+  test('reports the exit code when the child exits non-zero', async () => {
+    const proc = spawn(NODE, ['-e', 'process.exit(3)'], { stdio: 'pipe' });
+    await waitForExit(proc);
+
+    const state = describeLaunchState(proc, '', '');
+    expect(state).toContain('process exited with code 3');
+    expect(state).not.toContain('still running');
+  });
+
+  test('names the signal when the child is killed', async () => {
+    test.skip(
+      process.platform === 'win32',
+      'Windows emulates signals: a killed child reports an exit code, not a signal name',
+    );
+
+    const proc = spawn(NODE, LINGER, { stdio: 'pipe' });
+    proc.kill('SIGKILL');
+    await waitForExit(proc);
+
+    // The distinction this whole module exists for: an externally killed
+    // Electron is reported as such instead of as a bare connect refusal.
+    const state = describeLaunchState(proc, '', '');
+    expect(state).toContain('killed by SIGKILL');
+    expect(state).not.toContain('still running');
+  });
+
+  test('surfaces the CDP port owner only when the port is held', async () => {
+    const proc = spawn(NODE, LINGER, { stdio: 'pipe' });
+    try {
+      expect(describeLaunchState(proc, '', '')).toContain('nothing was listening on the CDP port');
+      expect(describeLaunchState(proc, '', '4321,8765')).toContain(
+        'CDP port LISTEN owner(s): 4321,8765',
+      );
+    } finally {
+      proc.kill('SIGKILL');
+      await waitForExit(proc);
+    }
+  });
+
+  test('captures the tail of child stderr and bounds it', async () => {
+    // Write past the cap so the bound is actually exercised, and end with a
+    // marker so we can prove it kept the *tail* rather than the head.
+    const overflow = OUTPUT_TAIL_LIMIT * 2;
+    const proc = spawn(
+      NODE,
+      ['-e', `process.stderr.write('x'.repeat(${overflow}) + 'FATAL-AT-THE-END')`],
+      { stdio: 'pipe' },
+    );
+    const tail = captureOutputTail(proc);
+    await waitForClose(proc);
+
+    const captured = tail();
+    expect(captured).toHaveLength(OUTPUT_TAIL_LIMIT);
+    expect(captured).toContain('FATAL-AT-THE-END');
+
+    const state = describeLaunchState(proc, captured, '');
+    expect(state).toContain('FATAL-AT-THE-END');
+  });
+
+  test('distinguishes uncaptured output from a child that wrote nothing', async () => {
+    const proc = spawn(NODE, LINGER, { stdio: 'pipe' });
+    try {
+      // Dev mode inherits the streams, so there is no tail to read -- that
+      // must not read as "the child said nothing", which is a real signal.
+      expect(describeLaunchState(proc, undefined, '')).toContain('output not captured');
+      expect(describeLaunchState(proc, '', '')).toContain('wrote nothing');
+    } finally {
+      proc.kill('SIGKILL');
+      await waitForExit(proc);
+    }
+  });
+});

--- a/e2e/rstudio/tests/panes/help/run_examples_blocking.test.ts
+++ b/e2e/rstudio/tests/panes/help/run_examples_blocking.test.ts
@@ -41,9 +41,17 @@ function writeFileCmd(path: string, content: string): string {
 
 test.describe('Help "Run examples" for blocking examples', () => {
   let installed = false;
+  let enhancedHelp = false;
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
+
+    // The "Run examples" link comes from R, not RStudio: tools::Rd2HTML emits
+    // it only as part of the enhanced HTML help introduced in R 4.2.0. On older
+    // R the link never renders, so the #17178 lockup is unreachable from the
+    // help pane and there is nothing here to exercise.
+    enhancedHelp = (await consoleActions.evalRLogical('getRversion() >= "4.2.0"')) === true;
+    if (!enhancedHelp) return;
 
     const pkgDir = `${rPath(sandbox.dir)}/${PKG}`;
 
@@ -112,6 +120,7 @@ ${MARKER_CALL}
   test('routes a Shiny-launching example to the console instead of locking up', async ({
     rstudioPage: page,
   }) => {
+    test.skip(!enhancedHelp, 'requires R >= 4.2.0 for enhanced HTML help (the "Run examples" link)');
     test.skip(!installed, `Could not install fixture package ${PKG}`);
 
     await consoleActions.clearConsole();

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -26,6 +26,10 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
   // load-bearing too -- the cleanup hooks unlink that exact file.
   const PROMPT = `Create a Shiny for R web app for a tip calculator. The app can only depend on packages that are already installed--nothing that isn't already installed. The app should be a single file named app.R in the current working directory. It should have a slider from $0 to $100 for the bill amount. It should have four buttons: 10%, 15%, 20%, and 25%. The output, the tip, should be based on the value in the slider and the chosen button. The buttons and slider should both be oriented horizontally, the slider above the buttons. The bill and tip amount should be displayed above the slider. The title of the page should be "Wacky Tip Calculator for R". Then run the app in the viewer pane and make sure that it can be seen. The app MUST be viewable in the RStudio viewer pane. Do NOT set options(shiny.launch.browser) and do NOT pass a launch.browser argument to runApp--RStudio is already configured to open the app in the Viewer pane. Then say "Wacky Tip Calculator for R has started" when the app starts running.`;
 
+  // Budget for the assistant to write app.R and get it running in the Viewer,
+  // sized for LLM tail latency -- observed whole-test durations are 90-108s.
+  const ASSISTANT_TURN_BUDGET_MS = 300000;
+
   test.beforeAll(async ({ rstudioPage: page }) => {
     // A cold-cache package install can outlast the global per-test timeout;
     // keep the headroom this install hook's ensurePackages() budget assumes.
@@ -99,6 +103,12 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
   test('Create and run R Shiny tip calculator', async ({ rstudioPage: page }) => {
     test.skip(missingPackages.length > 0, `Missing packages: ${missingPackages.join(', ')}`);
 
+    // Without this the test falls back to the 120s global timeout and cuts the
+    // poll below off at 40% of its budget -- a bare "Test timeout exceeded"
+    // instead of the poll's own diagnostic. Derived to keep the two in sync;
+    // the margin covers conversation setup and the 90s of Viewer assertions.
+    test.setTimeout(ASSISTANT_TURN_BUDGET_MS + 120000);
+
     // Start a fresh conversation
     await chatActions.startNewConversation();
 
@@ -115,7 +125,7 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
         }
       }
       return false;
-    }, 300000);
+    }, ASSISTANT_TURN_BUDGET_MS);
 
 
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -28,7 +28,14 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
 
   // Budget for the assistant to write app.R and get it running in the Viewer,
   // sized for LLM tail latency -- observed whole-test durations are 90-108s.
-  const ASSISTANT_TURN_BUDGET_MS = 300000;
+  //
+  // Capped below the 300s no-output watchdog in scripts/run-with-heartbeat.mjs
+  // (PW_HEARTBEAT_TIMEOUT_SECONDS, which only the Linux desktop engine
+  // overrides). The poll is silent while the assistant works, so a budget at
+  // or above that threshold lets the watchdog kill the whole shard instead of
+  // this one test failing with the poll's own diagnostic. Raising it means
+  // emitting progress from the poll first.
+  const ASSISTANT_TURN_BUDGET_MS = 240000;
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     // A cold-cache package install can outlast the global per-test timeout;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -122,6 +122,11 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
     // Send the deterministic prompt
     await chatActions.sendChatMessage(PROMPT);
 
+    // The no-output watchdog counts from the last output, not from here, so
+    // announce the wait: that resets its timer at poll start and makes the
+    // budget-vs-watchdog margin exact instead of a guess about setup silence.
+    console.log(`[shiny-app-r] awaiting assistant turn (budget ${ASSISTANT_TURN_BUDGET_MS / 1000}s)`);
+
     // Poll until the assistant completes. Handle Allow dialogs for each tool type.
     await chatActions.pollWithAllowDialogs(async () => {
       const messageCount = await chatPane.getMessageCount();


### PR DESCRIPTION
Test-suite fixes from the 2026.09.0+174 certification run
([34260015710](https://github.com/rstudio/rstudio/actions/runs/34260015710)).
Test-only; no product code changes, so no NEWS entry.

- **Guard the help "Run examples" test on R >= 4.2.0.** The link it asserts is
  emitted by R (`tools::Rd2HTML` enhanced HTML help, new in 4.2.0), not by
  RStudio, so the test can never pass on the macOS 14 cell's R 4.1.3. It now
  skips there with a reason.

- **Give `shiny-app-r` a timeout that clears its own turn budget.**
  `test.setTimeout` was set in `beforeAll` only, so the body ran under the 120s
  global while its poll asked for 300s. Budget is now 240s with a 360s test
  timeout, kept below the 300s no-output watchdog in `run-with-heartbeat.mjs`,
  and the poll logs once before it waits so the watchdog timer resets at a
  known point.

- **Report why a launch failed instead of a bare `ECONNREFUSED`.** Addresses
  #18522. A signal death before CDP is up is no longer treated as normal
  teardown, and the child's stdout/stderr are drained instead of discarded.
  Both failure paths now print a `[launch-state]` line (exit code / signal /
  still-running PID, plus the CDP port owner) and a `[launch-output]` tail.
  The logic sits in `fixtures/launch-diagnostics.ts` with unit coverage in
  `tests/harness/launch-diagnostics.test.ts`, so it runs without the RStudio
  binary. This does not fix #18522; it makes the next occurrence readable.