### PR TITLE
fix preferences dialog css height assertion

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogPaneBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogPaneBase.java
@@ -222,7 +222,12 @@ public abstract class PreferencesDialogPaneBase<T> extends VerticalPanel
       int width = PreferencesDialogConstants.PANEL_CONTAINER_WIDTH
             - PreferencesDialogConstants.SECTION_CHOOSER_WIDTH
             - PreferencesDialogConstants.SECTION_CHOOSER_PADDING;
-      panel.setSize(width + "px", PreferencesDialogConstants.panelContainerHeight());
+      panel.setWidth(width + "px");
+
+      // Set the height directly: GWT's setHeight() has a legacy IE assertion
+      // that cannot parse CSS expressions such as min() and calc().
+      panel.getElement().getStyle().setProperty("height",
+            PreferencesDialogConstants.panelContainerHeight());
    }
 
    private ProgressIndicator progressIndicator_;


### PR DESCRIPTION
### Intent

Opening Global Options with GWT assertions enabled fails because the responsive panel height uses `min()` and `calc()`, which GWT's legacy IE length assertion cannot parse.

### Approach

Set the tab panel's CSS height directly, preserving the existing responsive expression and width. Add a comment explaining why the GWT height setter must be bypassed.

### Automated Tests

- `ant javac` passed with JDK 17.
- `git diff --check` passed.
- No new automated tests for this direct CSS assignment; browser verification is described below.

### QA Notes

With GWT assertions enabled, open Global Options and switch between preference panes. Confirm there is no height assertion and that the dialog's buttons remain visible when resizing to a short window. Browser verification has not been run.

### Documentation

No documentation changes are needed. This is a follow-up fix to the responsive sizing introduced in #18732.

### Checklist

- [x] NEWS entry not required for this follow-up to an unreleased change.
- [x] Existing visual styling and accessibility behavior are preserved.
- [ ] A reviewer is assigned to this PR.
- [ ] This PR passes all local unit tests (Java compilation passed; unit tests were not run).
