### PR TITLE
use the platform default lock type in desktop mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - ([#18739](https://github.com/rstudio/rstudio/issues/18739)): Optimized RStudio Desktop startup time.
 
 ### Fixed
+- ([#18744](https://github.com/rstudio/rstudio/issues/18744)): RStudio Desktop now uses link-based file locks by default on macOS and Linux, matching RStudio Server, so sessions from both editions sharing a data directory or a project on a network drive no longer mistake each other's live locks for stale ones.
 - ([#18677](https://github.com/rstudio/rstudio/issues/18677)): Fixed Windows subprocess detection reporting unrelated processes as children after process ID reuse.
 - ([#18742](https://github.com/rstudio/rstudio/issues/18742)): Fixed an issue where the Global Options dialog could push the OK and Apply buttons off screen in short windows.
 - ([#18736](https://github.com/rstudio/rstudio/issues/18736)): Fixed an issue where delayed document outline initialization could reactivate a closed Source column and leave a new document without an active editor

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2472,8 +2472,11 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
             monitor::client().createLogDestination(core::system::generateShortenedUuid(), log::LogLevel::WARN, options.programIdentity()));
       }
 
-      // initialize file lock config
-      FileLock::initialize(desktopMode ? FileLock::LOCKTYPE_ADVISORY : FileLock::LOCKTYPE_LINKBASED);
+      // initialize file lock config. use the platform default (advisory on
+      // Windows, link-based elsewhere) in every mode: desktop and server
+      // sessions can share a data directory, and each type misreads the
+      // other's live locks as stale (#18744)
+      FileLock::initialize();
 
       // re-initialize log for desktop mode
       if (desktopMode)

--- a/src/cpp/session/modules/chat/ChatInstallLock.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.cpp
@@ -66,7 +66,7 @@ std::string sessionsInUseMessage(FileLock::LockType lockType)
       "Close Posit Assistant in your other sessions and try again.";
 
    // Advisory locks vanish with their process; only link-based locks
-   // (server) can linger up to the staleness timeout after a hard crash.
+   // (macOS, Linux) can linger up to the staleness timeout after a hard crash.
    if (lockType == FileLock::LOCKTYPE_LINKBASED)
    {
       message += " If another session ended unexpectedly, this may take up "

--- a/src/cpp/session/modules/chat/ChatInstallLock.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.hpp
@@ -42,8 +42,8 @@ namespace install_lock {
 // - An "in use" lock (locks/sessions/<ownerId>.lock) is held while this
 //   session runs the chat backend and/or NES agent from the user-data
 //   install. It is a *held* core::FileLock, never a marker file we clean up:
-//   advisory locks (desktop) are released by the OS the moment the process
-//   dies, and link-based locks (server) go stale via the existing PID/
+//   advisory locks (Windows) are released by the OS the moment the process
+//   dies, and link-based locks (macOS, Linux) go stale via the existing PID/
 //   heartbeat machinery — so a crashed session cannot cause a persistent
 //   false "in use" report.
 // - A mutation lock (locks/install.lock) serializes install/update/uninstall
@@ -55,11 +55,11 @@ namespace install_lock {
 // install.lock. Simultaneous racers each see the other and back off.
 //
 // The protocol assumes every process sharing the locks directory uses the
-// same lock type. Mixing types (e.g. a desktop rsession's advisory locks
-// alongside a server rsession's link-based locks over one home directory)
-// makes each side misread the other's live locks as stale — a pre-existing
-// core::FileLock limitation; a uniform type can be forced via the
-// file-locks configuration file.
+// same lock type. FileLock::initialize() picks one default per platform
+// regardless of desktop/server mode, so sessions sharing a home directory
+// agree; the file-locks configuration file can still override it. Mixing
+// types makes each side misread the other's live locks as stale -- a
+// pre-existing core::FileLock limitation.
 //
 // All methods must be called on the main thread (both subprocess lifecycles
 // run their callbacks there via callbacksRequireMainThread); no internal
@@ -83,8 +83,8 @@ public:
    //   file and permanently refuses this process's starts as a spurious
    //   "update in progress" (#18571).
    // lockType: test seam; production omits it and uses the process default
-   //   configured by FileLock::initialize() (advisory in desktop mode,
-   //   link-based in server mode).
+   //   configured by FileLock::initialize() (advisory on Windows,
+   //   link-based elsewhere).
    InstallLock(const core::FilePath& locksDir,
                const std::string& ownerId,
                const boost::optional<core::FileLock::LockType>& lockType =

--- a/src/cpp/session/modules/chat/ChatInstallLock.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.hpp
@@ -57,9 +57,10 @@ namespace install_lock {
 // The protocol assumes every process sharing the locks directory uses the
 // same lock type. FileLock::initialize() picks one default per platform
 // regardless of desktop/server mode, so sessions sharing a home directory
-// agree; the file-locks configuration file can still override it. Mixing
-// types makes each side misread the other's live locks as stale -- a
-// pre-existing core::FileLock limitation.
+// agree; on macOS and Linux the file-locks configuration file can still
+// override it (Windows is always advisory). Mixing types makes each side
+// misread the other's live locks as stale -- a pre-existing core::FileLock
+// limitation.
 //
 // All methods must be called on the main thread (both subprocess lifecycles
 // run their callbacks there via callbacksRequireMainThread); no internal

--- a/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
@@ -283,9 +283,9 @@ TEST_F(ChatInstallLock, LocksDirAutoCreated)
 
 TEST_F(ChatInstallLock, AdvisoryLockAcrossProcessesBlocksMutationAndClearsOnExit)
 {
-   // The production desktop path: advisory locks conflict across processes
-   // and are released by the kernel the moment the holder exits — even when
-   // the holder never cleans up its lock file.
+   // The Windows default (or a file-locks opt-in): advisory locks conflict
+   // across processes and are released by the kernel the moment the holder
+   // exits — even when the holder never cleans up its lock file.
    InstallLock advisoryLocal(
       locksDir_, "session-local", FileLock::LOCKTYPE_ADVISORY);
 


### PR DESCRIPTION
### Intent

Addresses #18744.

RStudio Desktop forced advisory file locks while RStudio Server used link-based locks. The two implementations cannot read each other: a link-based probe sees an advisory lock file (empty, never refreshed) as stale, and an advisory probe sees a link-based lock file (no fcntl holder) as free. When both editions share a data directory, or when a Desktop project lives on a network mount where fcntl fails (#3521), a starting session adopts a live session's source database.

### Approach

- Desktop sessions now call the no-argument `FileLock::initialize()`, so every mode uses the platform default: advisory on Windows (link-based is not implemented there, and Windows byte-range locks are mandatory and SMB-native), link-based on macOS and Linux. The `file-locks` configuration file still overrides the type.
- Updated the comments in the Posit Assistant install lock that described the old desktop/server split.

This finishes what #5668 originally set out to do in 2019; that PR was narrowed during review to keep advisory locks on Desktop. It is complementary to #18745, which makes recovery inspect both lock types (a safety net for customized configs and older binaries), and to the namespace separation proposed in #18746. Note that the `isLockedByAnyType` comment in #18745 describes the old defaults and can be reworded once both land.

### Automated Tests

None added. The change is a default selection; `FileLockTests` and `ChatInstallLockTests` exercise both implementations explicitly. `SessionMain.cpp` was syntax-checked against the existing build's compile flags. A full rebuild and test run were not performed locally.

### QA Notes

- On macOS or Linux, start a Desktop session with no project and confirm `~/.local/share/rstudio/sources/session-<id>/lock_file` contains the rsession PID (link-based) rather than being empty (advisory), and that it is touched roughly every 20 seconds.
- Start a Server-mode session and a Desktop session sharing one `RSTUDIO_DATA_HOME`, in both orders. Neither session's `sources/session-<id>` directory should be renamed, and both should still create documents.
- Kill a Desktop rsession with SIGKILL and relaunch. The orphaned source database should be recovered on the next start.
- Open a project on an SMB or NFS mount from Desktop, then Session > New Session; the first session should keep saving.
- Windows behavior is unchanged.
- On macOS or Linux, open a project on an SMB or NFS mount, stall the mount (e.g. pause the server or block the port) for longer than 30 seconds, then launch a second Desktop session while it is stalled. Until #18747 lands, the second session may adopt the first session's source database; this is the known timeout tradeoff of link-based locks, not a regression to fix in this PR.

### Documentation

NEWS entry added under Fixed.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility) (no UI changes)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

