### PR TITLE
Update installed Node.js to 24.21.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,5 +17,5 @@
 - ([#18722](https://github.com/rstudio/rstudio/issues/18722)): Fixed an issue where the diagnostics system reported "unexpected end of document" for R scripts ending with a semicolon
 
 ### Dependencies
--
+- Node.js 24.21.0 (GitHub Copilot, Posit Assistant)
 

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -341,7 +341,7 @@ set(PANDOC_VERSION "3.2" CACHE INTERNAL "Pandoc version")
 set(RSTUDIO_NODE_VERSION "22.22.2" CACHE INTERNAL "Node version for building")
 
 # node version installed with the product
-set(RSTUDIO_INSTALLED_NODE_VERSION "22.23.2" CACHE INTERNAL "Node version installed with product")
+set(RSTUDIO_INSTALLED_NODE_VERSION "24.21.0" CACHE INTERNAL "Node version installed with product")
 
 # quarto support
 

--- a/dependencies/tools/rstudio-tools.cmd
+++ b/dependencies/tools/rstudio-tools.cmd
@@ -67,7 +67,7 @@ call :set-java-home
 set RSTUDIO_NODE_VERSION=22.22.2
 
 :: Node version installed with the product
-set RSTUDIO_INSTALLED_NODE_VERSION=22.23.2
+set RSTUDIO_INSTALLED_NODE_VERSION=24.21.0
 
 :: The base URL where RStudio build tools are available for download.
 set RSTUDIO_BUILDTOOLS=https://rstudio-buildtools.s3.amazonaws.com

--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -67,7 +67,7 @@ export RSTUDIO_NODE_VERSION="22.22.2"
 #
 # In addition to updating the version here, search the entire repo for other instances of
 # RSTUDIO_INSTALLED_NODE_VERSION and update to match.
-export RSTUDIO_INSTALLED_NODE_VERSION="22.23.2"
+export RSTUDIO_INSTALLED_NODE_VERSION="24.21.0"
 
 # actual directory name of the node installation used
 # mainly relevant for cases like macOS, where we have an -arm64 variant installed

--- a/dependencies/tools/upload-node.sh
+++ b/dependencies/tools/upload-node.sh
@@ -10,7 +10,7 @@
 # installed with the RStudio IDE by RSTUDIO_INSTALLED_NODE_VERSION.
 
 # Modify to set the node.js version to upload
-NODE_VERSION="v22.23.2"
+NODE_VERSION="v24.21.0"
 
 # Check that we're logged in with AWS
 aws sts get-caller-identity || aws sso login


### PR DESCRIPTION
Moves the Node.js version shipped with the product (`RSTUDIO_INSTALLED_NODE_VERSION`) from 22.23.2 to 24.21.0, the current Node 24 Active LTS. This is the `node` binary used by GitHub Copilot and Posit Assistant.

The build-time Node version (`RSTUDIO_NODE_VERSION`) is unchanged at 22.22.2.

| | Old | New |
| --- | --- | --- |
| `RSTUDIO_INSTALLED_NODE_VERSION` | 22.23.2 | 24.21.0 |
| `RSTUDIO_NODE_VERSION` | 22.22.2 | 22.22.2 |

Verified: all six platform archives uploaded to `s3://rstudio-buildtools/node/v24.21.0/` (darwin-arm64, darwin-x64, linux-arm64, linux-x64, win-x64, win-arm64), and `install-npm-dependencies` downloads and extracts them locally — the installed binary reports `v24.21.0`.

Closes #18671.