### PR TITLE
don't activate the app during automation runs on macos

### DIFF
--- a/src/node/desktop/src/main/application-launch.ts
+++ b/src/node/desktop/src/main/application-launch.ts
@@ -19,6 +19,7 @@ import { existsSync, readdirSync } from 'fs';
 import { setenv, unsetenv } from '../core/environment';
 import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../core/r-user-data';
 import { MainWindow } from './main-window';
+import { isAutomated } from './utils';
 import { app } from 'electron';
 
 export interface LaunchRStudioOptions {
@@ -63,6 +64,11 @@ export class ApplicationLaunch {
     // in devmode, we need to pass the directory path when launching the application;
     // for package builds, we have no such requirement
     const argv = app.isPackaged ? [] : [process.argv[1]];
+
+    // keep the relaunched instance from stealing focus during automation runs
+    if (isAutomated()) {
+      argv.push('--automation-agent');
+    }
 
     // resolve working directory
     let workingDir = app.getPath('home');

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -46,6 +46,7 @@ import {
   findComponents,
   initializeLang,
   initializeSharedSecret,
+  isAutomated,
   loadRWebsite,
   raiseAndActivateWindow,
   removeStaleOptionsLockfile,
@@ -564,6 +565,12 @@ export class Application implements AppState {
         owner,
         baseUrl,
       );
+    }
+
+    // windowOpening() created the window hidden; surface it without pulling
+    // OS focus away from whatever the user is doing while the tests run.
+    if (isAutomated()) {
+      newWindow.showInactive();
     }
   }
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -1353,7 +1353,20 @@ export class GwtCallback extends EventEmitter {
     if (window) {
       return window;
     }
-    return isAutomated() ? this.mainWindow.window : undefined;
+
+    if (!isAutomated()) {
+      return undefined;
+    }
+
+    // AppKit holds a sheet on a minimized or hidden window until the window
+    // comes back, and the test run would hang on a dialog it can never reach;
+    // a parentless dialog that activates the app is the lesser evil there.
+    const main = this.mainWindow.window;
+    if (!main.isDestroyed() && main.isVisible() && !main.isMinimized()) {
+      return main;
+    }
+
+    return undefined;
   }
 
   /**

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -225,13 +225,12 @@ export class GwtCallback extends EventEmitter {
           openDialogOptions.filters = parseFilter(filter);
         }
 
-        let focusedWindow = BrowserWindow.getFocusedWindow();
-        if (focusOwner) {
-          focusedWindow = this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window;
-        }
+        const focusedWindow = this.dialogParentWindow(
+          focusOwner ? this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window : null,
+        );
         if (focusedWindow) {
           return appState().modalTracker.trackElectronModalAsync(async () =>
-            dialog.showOpenDialog(focusedWindow!, openDialogOptions),
+            dialog.showOpenDialog(focusedWindow, openDialogOptions),
           );
         } else {
           return appState().modalTracker.trackElectronModalAsync(async () => dialog.showOpenDialog(openDialogOptions));
@@ -280,13 +279,12 @@ export class GwtCallback extends EventEmitter {
           filters.unshift({ name: extension, extensions: [extension] });
         }
         saveDialogOptions['filters'] = filters;
-        let focusedWindow = BrowserWindow.getFocusedWindow();
-        if (focusOwner) {
-          focusedWindow = this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window;
-        }
+        const focusedWindow = this.dialogParentWindow(
+          focusOwner ? this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window : null,
+        );
         if (focusedWindow) {
           return appState().modalTracker.trackElectronModalAsync(async () =>
-            dialog.showSaveDialog(focusedWindow!, saveDialogOptions),
+            dialog.showSaveDialog(focusedWindow, saveDialogOptions),
           );
         } else {
           return appState().modalTracker.trackElectronModalAsync(async () => dialog.showSaveDialog(saveDialogOptions));
@@ -304,14 +302,13 @@ export class GwtCallback extends EventEmitter {
           properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
         };
 
-        let focusedWindow = BrowserWindow.getFocusedWindow();
-        if (focusOwner) {
-          focusedWindow = this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window;
-        }
+        const focusedWindow = this.dialogParentWindow(
+          focusOwner ? this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window : null,
+        );
 
         if (focusedWindow) {
           return appState().modalTracker.trackElectronModalAsync(async () =>
-            dialog.showOpenDialog(focusedWindow!, openDialogOptions),
+            dialog.showOpenDialog(focusedWindow, openDialogOptions),
           );
         } else {
           return appState().modalTracker.trackElectronModalAsync(async () => dialog.showOpenDialog(openDialogOptions));
@@ -698,7 +695,7 @@ export class GwtCallback extends EventEmitter {
           };
         }
 
-        const focusedWindow = BrowserWindow.getFocusedWindow();
+        const focusedWindow = this.dialogParentWindow();
         if (focusedWindow) {
           return appState().modalTracker.trackElectronModalAsync(async () =>
             dialog.showMessageBox(focusedWindow, openDialogOptions),
@@ -1162,7 +1159,7 @@ export class GwtCallback extends EventEmitter {
           detail: "What's New information is not available.",
           buttons: ['OK'],
         };
-        const focusedWindow = BrowserWindow.getFocusedWindow();
+        const focusedWindow = this.dialogParentWindow();
         if (focusedWindow) {
           void appState().modalTracker.trackElectronModalAsync(async () =>
             dialog.showMessageBox(focusedWindow, msgBoxOptions),
@@ -1344,6 +1341,19 @@ export class GwtCallback extends EventEmitter {
    */
   unregisterOwner(owner: GwtWindow): void {
     this.owners.delete(owner);
+  }
+
+  /**
+   * Parent window for a native dialog. Without one, macOS runs the dialog
+   * detached and activates the app; in automation mode the app is never
+   * focused, so fall back to the main window and get a sheet instead.
+   */
+  dialogParentWindow(preferred?: BrowserWindow | null): BrowserWindow | undefined {
+    const window = preferred ?? BrowserWindow.getFocusedWindow();
+    if (window) {
+      return window;
+    }
+    return isAutomated() ? this.mainWindow.window : undefined;
   }
 
   /**

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -20,6 +20,7 @@ import { GwtWindow } from './gwt-window';
 import { MainWindow } from './main-window';
 import { appState } from './app-state';
 import { DesktopBrowserWindow } from './desktop-browser-window';
+import { isAutomated } from './utils';
 
 const SOURCE_WINDOW_PREFIX = '_rstudio_satellite_source_window_';
 
@@ -129,6 +130,10 @@ export class SatelliteWindow extends GwtWindow {
       action: 'allow',
       overrideBrowserWindowOptions: {
         autoHideMenuBar: true,
+        // Electron shows window.open() windows immediately, which on macOS
+        // activates the app; Application.windowCreated() surfaces them with
+        // showInactive() instead during automation runs.
+        show: !isAutomated(),
         webPreferences: {
           additionalArguments: ['--api-keys=desktopInfo|desktop'],
           preload: DesktopBrowserWindow.getPreload(),

--- a/src/node/desktop/src/main/secondary-window.ts
+++ b/src/node/desktop/src/main/secondary-window.ts
@@ -15,6 +15,7 @@
 
 import { BrowserWindow, WebContents } from 'electron';
 import { DesktopBrowserWindow } from './desktop-browser-window';
+import { isAutomated } from './utils';
 
 export class SecondaryWindow extends DesktopBrowserWindow {
   constructor(
@@ -61,6 +62,8 @@ export class SecondaryWindow extends DesktopBrowserWindow {
       action: 'allow',
       overrideBrowserWindowOptions: {
         autoHideMenuBar: true,
+        // See SatelliteWindow.windowOpening()
+        show: !isAutomated(),
         width: width,
         height: height,
         webPreferences: {

--- a/src/node/desktop/test/unit/main/application-launch.test.ts
+++ b/src/node/desktop/test/unit/main/application-launch.test.ts
@@ -15,13 +15,20 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
+import sinon from 'sinon';
 import fs from 'fs';
+import childProcess, { ChildProcess } from 'child_process';
+import { app } from 'electron';
 
 import { ApplicationLaunch, resolveProjectFile } from '../../../src/main/application-launch';
 import { MainWindow } from '../../../src/main/main-window';
 import { createSinonStubInstance } from '../unit-utils';
 
 describe('ApplicationLaunch', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('static init returns new instance', () => {
     const appLaunch = ApplicationLaunch.init();
     assert.isObject(appLaunch);
@@ -35,6 +42,22 @@ describe('ApplicationLaunch', () => {
     const createdWindow = appLaunch.mainWindow as MainWindow;
 
     assert.strictEqual(testWindow, createdWindow, 'Test window does not match created window');
+  });
+
+  it('launchRStudio forwards --automation-agent to the relaunched instance', () => {
+    const spawnStub = sinon.stub(childProcess, 'spawn').returns({ unref: sinon.stub() } as unknown as ChildProcess);
+    const appLaunch = ApplicationLaunch.init();
+
+    appLaunch.launchRStudio({});
+    assert.notInclude(spawnStub.firstCall.args[1] as string[], '--automation-agent');
+
+    app.commandLine.appendSwitch('automation-agent');
+    try {
+      appLaunch.launchRStudio({});
+    } finally {
+      app.commandLine.removeSwitch('automation-agent');
+    }
+    assert.include(spawnStub.secondCall.args[1] as string[], '--automation-agent');
   });
 
   it('Resolve Empty Project File Path', () => {

--- a/src/node/desktop/test/unit/main/gwt-callback.test.ts
+++ b/src/node/desktop/test/unit/main/gwt-callback.test.ts
@@ -16,7 +16,7 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
-import { BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
 import { createSinonStubInstance, StubbedClass } from '../unit-utils';
 
 import { GwtCallback } from '../../../src/main/gwt-callback';
@@ -51,6 +51,37 @@ describe('DesktopCallback', () => {
 
   it('can be constructed', () => {
     assert.isNotEmpty(callback);
+  });
+
+  describe('dialogParentWindow', () => {
+    // a parentless native dialog activates the app on macOS, so automation
+    // runs must always get a parent even though the app is never focused
+    it('prefers the requested window, then the focused window', () => {
+      const preferred = fakeBrowserWindow() as unknown as BrowserWindow;
+      const focused = fakeBrowserWindow() as unknown as BrowserWindow;
+      sinon.stub(BrowserWindow, 'getFocusedWindow').returns(focused);
+
+      assert.strictEqual(callback.dialogParentWindow(preferred), preferred);
+      assert.strictEqual(callback.dialogParentWindow(), focused);
+    });
+
+    it('leaves the dialog parentless when nothing is focused', () => {
+      sinon.stub(BrowserWindow, 'getFocusedWindow').returns(null);
+      assert.isUndefined(callback.dialogParentWindow());
+    });
+
+    it('falls back to the main window in automation mode', () => {
+      const main = fakeBrowserWindow() as unknown as BrowserWindow;
+      mainWindow.window = main;
+      sinon.stub(BrowserWindow, 'getFocusedWindow').returns(null);
+
+      app.commandLine.appendSwitch('automation-agent');
+      try {
+        assert.strictEqual(callback.dialogParentWindow(), main);
+      } finally {
+        app.commandLine.removeSwitch('automation-agent');
+      }
+    });
   });
 
   describe('desktop_bring_main_frame_behind_active', () => {

--- a/src/node/desktop/test/unit/main/gwt-callback.test.ts
+++ b/src/node/desktop/test/unit/main/gwt-callback.test.ts
@@ -22,8 +22,9 @@ import { createSinonStubInstance, StubbedClass } from '../unit-utils';
 import { GwtCallback } from '../../../src/main/gwt-callback';
 import { MainWindow } from '../../../src/main/main-window';
 
-function fakeBrowserWindow(state?: { visible: boolean; minimized: boolean }) {
+function fakeBrowserWindow(state?: { visible?: boolean; minimized?: boolean; destroyed?: boolean }) {
   return {
+    isDestroyed: sinon.stub().returns(state?.destroyed ?? false),
     isVisible: sinon.stub().returns(state?.visible ?? true),
     isMinimized: sinon.stub().returns(state?.minimized ?? false),
     show: sinon.stub(),
@@ -78,6 +79,22 @@ describe('DesktopCallback', () => {
       app.commandLine.appendSwitch('automation-agent');
       try {
         assert.strictEqual(callback.dialogParentWindow(), main);
+      } finally {
+        app.commandLine.removeSwitch('automation-agent');
+      }
+    });
+
+    // a sheet on a window that is not on screen is held until the window comes
+    // back, so the run would hang on a dialog it can never dismiss
+    it('stays parentless in automation mode when the main window is off screen', () => {
+      sinon.stub(BrowserWindow, 'getFocusedWindow').returns(null);
+
+      app.commandLine.appendSwitch('automation-agent');
+      try {
+        for (const state of [{ minimized: true }, { visible: false }, { destroyed: true }]) {
+          mainWindow.window = fakeBrowserWindow(state) as unknown as BrowserWindow;
+          assert.isUndefined(callback.dialogParentWindow(), JSON.stringify(state));
+        }
       } finally {
         app.commandLine.removeSwitch('automation-agent');
       }

--- a/src/node/desktop/test/unit/main/satellite-window.test.ts
+++ b/src/node/desktop/test/unit/main/satellite-window.test.ts
@@ -18,7 +18,7 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 import { createSinonStubInstance, isWindowsDocker } from '../unit-utils';
 
-import { BrowserWindow } from 'electron';
+import { app, BrowserWindow } from 'electron';
 
 import { SatelliteWindow } from '../../../src/main/satellite-window';
 import { MainWindow } from '../../../src/main/main-window';
@@ -41,6 +41,21 @@ if (!isWindowsDocker()) {
 
       clearApplicationSingleton();
       sinon.restore();
+    });
+
+    it('windowOpening creates the window hidden only in automation mode', () => {
+      const showOption = () => {
+        const opening = SatelliteWindow.windowOpening();
+        return opening.action === 'allow' ? opening.overrideBrowserWindowOptions?.show : undefined;
+      };
+      assert.isTrue(showOption());
+
+      app.commandLine.appendSwitch('automation-agent');
+      try {
+        assert.isFalse(showOption());
+      } finally {
+        app.commandLine.removeSwitch('automation-agent');
+      }
     });
 
     it('construction creates a hidden BrowserWindow', () => {

--- a/src/node/desktop/test/unit/main/secondary-window.test.ts
+++ b/src/node/desktop/test/unit/main/secondary-window.test.ts
@@ -16,6 +16,7 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import { app } from 'electron';
 
 import { isWindowsDocker } from '../unit-utils';
 import { SecondaryWindow } from '../../../src/main/secondary-window';
@@ -31,6 +32,21 @@ if (!isWindowsDocker()) {
     afterEach(() => {
       clearApplicationSingleton();
       sinon.restore();
+    });
+
+    it('windowOpening creates the window hidden only in automation mode', () => {
+      const showOption = () => {
+        const opening = SecondaryWindow.windowOpening(800, 600);
+        return opening.action === 'allow' ? opening.overrideBrowserWindowOptions?.show : undefined;
+      };
+      assert.isTrue(showOption());
+
+      app.commandLine.appendSwitch('automation-agent');
+      try {
+        assert.isFalse(showOption());
+      } finally {
+        app.commandLine.removeSwitch('automation-agent');
+      }
     });
 
     it('construction creates a hidden BrowserWindow', () => {


### PR DESCRIPTION
## Intent

Keep RStudio Desktop from bringing itself to the front while the Playwright suite runs locally on macOS. Most `show()`/`focus()` calls in the Electron main were already gated on `--automation-agent`, but three paths still activated the app.

## Approach

- **`window.open()` windows** (help popout, Review Changes, plot zoom, Shiny app window, chat satellite, source windows). Electron shows these immediately, and `NativeWindowMac::Show()` calls `activateIgnoringOtherApps:YES`. `SatelliteWindow.windowOpening()` and `SecondaryWindow.windowOpening()` now pass `show: false` in automation mode, and `Application.windowCreated()` surfaces the configured window with `showInactive()`.
- **Restart relaunch.** `ApplicationLaunch.launchRStudio()` spawned the new instance with no switches, so it showed its main window normally. It now forwards `--automation-agent`.
- **Parentless native dialogs.** `BrowserWindow.getFocusedWindow()` is always null in automation (the app is never active), so the file/message dialogs fell through to the parentless branch, and a detached dialog activates the app. A `dialogParentWindow()` helper falls back to the main window in automation mode so the dialog becomes a sheet. Behavior outside automation is unchanged.

## Verification

Sampled the frontmost macOS app every 0.5s (via `osascript`) while running specs through `npm run test:desktop-dev`:

| Run | Electron frontmost samples | Result |
|---|---|---|
| main, `help_popout_theme` | 4 | 3 passed |
| this branch, `help_popout_theme` | 0 | 3 passed |
| this branch, viewer zoom + release notes + shiny window close + plots pane + review changes theme | 0 | 23 passed |

Desktop unit tests (`npm test`): 4 new tests covering `windowOpening()`, the relaunch argv, and `dialogParentWindow()`; `npm run lint` and `npm run typecheck` clean. The relaunch path has no local e2e coverage (its only spec, `uninstall-posit-ai`, needs Posit AI credentials), so it is covered by the unit test only.

Residual: `showInactive()` is `orderFrontRegardless` on macOS, so the window is still raised above other apps' windows without taking focus. Not raising it at all risks Chromium treating the occluded window as hidden and stalling rendering, so that is left as is.

Developer-only change; no NEWS entry.
