### PR TITLE
deny duplicate named windows before electron creates them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,6 @@
 - ([#18739](https://github.com/rstudio/rstudio/issues/18739)): Optimized RStudio Desktop startup time.
 
 ### Fixed
-- ([#18775](https://github.com/rstudio/rstudio/issues/18775)): Fixed an issue in RStudio Desktop where opening a named satellite or secondary window while a window of that name was already open could leave behind an extra, unmanaged window.
 - ([#18735](https://github.com/rstudio/rstudio/issues/18735)): Fixed an issue on Windows where RStudio failed to start when the command prompt was disabled by Group Policy.
 - ([#18744](https://github.com/rstudio/rstudio/issues/18744)): RStudio Desktop now uses link-based file locks by default on macOS and Linux, matching RStudio Server, so sessions from both editions sharing a data directory or a project on a network drive no longer mistake each other's live locks for stale ones.
 - ([#18677](https://github.com/rstudio/rstudio/issues/18677)): Fixed Windows subprocess detection reporting unrelated processes as children after process ID reuse.

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - ([#18739](https://github.com/rstudio/rstudio/issues/18739)): Optimized RStudio Desktop startup time.
 
 ### Fixed
+- ([#18775](https://github.com/rstudio/rstudio/issues/18775)): Fixed an issue in RStudio Desktop where opening a named satellite or secondary window while a window of that name was already open could leave behind an extra, unmanaged window.
 - ([#18735](https://github.com/rstudio/rstudio/issues/18735)): Fixed an issue on Windows where RStudio failed to start when the command prompt was disabled by Group Policy.
 - ([#18744](https://github.com/rstudio/rstudio/issues/18744)): RStudio Desktop now uses link-based file locks by default on macOS and Linux, matching RStudio Server, so sessions from both editions sharing a data directory or a project on a network drive no longer mistake each other's live locks for stale ones.
 - ([#18677](https://github.com/rstudio/rstudio/issues/18677)): Fixed Windows subprocess detection reporting unrelated processes as children after process ID reuse.

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -49,10 +49,12 @@ export interface AppState {
   sessionEarlyExitCode: number;
   startupDelayMs: number;
   prepareForWindow(pendingWindow: PendingWindow): void;
-  windowOpening():
+  windowOpening(
+    frameName: string,
+  ):
     | { action: 'deny' }
     | { action: 'allow'; overrideBrowserWindowOptions?: Electron.BrowserWindowConstructorOptions | undefined };
-  windowCreated(newWindow: BrowserWindow, owner: WebContents, baseUrl?: string): void;
+  windowCreated(newWindow: BrowserWindow, owner: WebContents, frameName: string, baseUrl?: string): void;
   server?: Server;
   client?: Client;
   eventBus?: TypedEventEmitter<EventBusTypes>;

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -516,12 +516,23 @@ export class Application implements AppState {
   windowOpening():
     | { action: 'deny' }
     | { action: 'allow'; overrideBrowserWindowOptions?: Electron.BrowserWindowConstructorOptions | undefined } {
-    // no additional config if pending window is a satellite
-    for (const pendingWindow of this.pendingWindows) {
+    if (this.pendingWindows.length > 0) {
+      const pendingWindow = this.pendingWindows[0];
+
+      // a window of this name is already open: activate it instead. This has
+      // to be denied here, before Electron creates the window; a denied
+      // request never reaches windowCreated(), so consume the pending entry.
+      const existingWindow = this.windowTracker.getWindow(pendingWindow.name)?.window;
+      if (existingWindow) {
+        this.pendingWindows.shift();
+        raiseAndActivateWindow(existingWindow);
+        return { action: 'deny' };
+      }
+
+      // no additional config if pending window is a satellite
       if (pendingWindow.type === 'satellite') {
         return SatelliteWindow.windowOpening();
       }
-      break;
     }
 
     // determine size for secondary window
@@ -538,14 +549,6 @@ export class Application implements AppState {
     // check if we have a pending window waiting to come up
     const pendingWindow = this.pendingWindows.shift();
     if (pendingWindow) {
-      // check for an existing window of this name
-      const existingWindow = this.windowTracker.getWindow(pendingWindow.name)?.window;
-      if (existingWindow) {
-        // activate the existing window then deny creation of new window
-        raiseAndActivateWindow(existingWindow);
-        return;
-      }
-
       if (pendingWindow.type === 'satellite') {
         configureSatelliteWindow(pendingWindow, newWindow, owner);
       } else {

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -513,12 +513,33 @@ export class Application implements AppState {
     this.pendingWindows.push(pendingWindow);
   }
 
-  windowOpening():
+  /**
+   * Returns the pending entry queued for a window.open() of this name, if any,
+   * leaving it at the head of the queue.
+   *
+   * Entries queued ahead of it are stale: when a window of the requested name
+   * is already open in the opener's browsing context group, Chromium navigates
+   * that window instead of creating one, so neither windowOpening() nor
+   * windowCreated() ever sees the request. Drop them here so they can't attach
+   * to a later, unrelated request.
+   */
+  private pendingWindowFor(frameName: string): PendingWindow | undefined {
+    const index = this.pendingWindows.findIndex((pending) => pending.name === frameName);
+    if (index === -1) {
+      return undefined;
+    }
+
+    this.pendingWindows.splice(0, index);
+    return this.pendingWindows[0];
+  }
+
+  windowOpening(
+    frameName: string,
+  ):
     | { action: 'deny' }
     | { action: 'allow'; overrideBrowserWindowOptions?: Electron.BrowserWindowConstructorOptions | undefined } {
-    if (this.pendingWindows.length > 0) {
-      const pendingWindow = this.pendingWindows[0];
-
+    const pendingWindow = this.pendingWindowFor(frameName);
+    if (pendingWindow) {
       // a window of this name is already open: activate it instead. This has
       // to be denied here, before Electron creates the window; a denied
       // request never reaches windowCreated(), so consume the pending entry.
@@ -545,10 +566,11 @@ export class Application implements AppState {
   /**
    * Configures new Secondary or Satellite window
    */
-  windowCreated(newWindow: BrowserWindow, owner: WebContents, baseUrl?: string): void {
+  windowCreated(newWindow: BrowserWindow, owner: WebContents, frameName: string, baseUrl?: string): void {
     // check if we have a pending window waiting to come up
-    const pendingWindow = this.pendingWindows.shift();
+    const pendingWindow = this.pendingWindowFor(frameName);
     if (pendingWindow) {
+      this.pendingWindows.shift();
       if (pendingWindow.type === 'satellite') {
         configureSatelliteWindow(pendingWindow, newWindow, owner);
       } else {

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -242,11 +242,11 @@ export class DesktopBrowserWindow extends EventEmitter {
 
       // configure window creation; we'll associate the resulting BrowserWindow with our
       // window wrapper type via 'did-create-window' below
-      return appState().windowOpening();
+      return appState().windowOpening(details.frameName);
     });
 
-    this.window.webContents.on('did-create-window', (newWindow) => {
-      appState().windowCreated(newWindow, this.window.webContents, this.options.baseUrl);
+    this.window.webContents.on('did-create-window', (newWindow, details) => {
+      appState().windowCreated(newWindow, this.window.webContents, details.frameName, this.options.baseUrl);
     });
 
     // calling event.preventDefault() prevents navigation

--- a/src/node/desktop/test/unit/main/application.test.ts
+++ b/src/node/desktop/test/unit/main/application.test.ts
@@ -15,6 +15,7 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
+import sinon from 'sinon';
 
 import fs from 'fs';
 import path from 'path';
@@ -27,6 +28,9 @@ import { clearCoreSingleton } from '../../../src/core/core-state';
 import { randomString } from '../../../src/main/utils';
 import { FilePath } from '../../../src/core/file-path';
 import { kRunDiagnosticsOption } from '../../../src/main/args-manager';
+import { DesktopBrowserWindow } from '../../../src/main/desktop-browser-window';
+import { MainWindow } from '../../../src/main/main-window';
+import { PendingWindow } from '../../../src/main/pending-window';
 
 describe('Application', () => {
   before(() => {
@@ -102,6 +106,84 @@ describe('Application', () => {
       assert.isTrue(app.runDiagnostics);
     });
   });
+  describe('Window creation', () => {
+    // stands in for a tracked window; only the methods the tracker and
+    // raiseAndActivateWindow() touch are provided
+    function trackedWindow(): { tracked: DesktopBrowserWindow; focus: sinon.SinonStub } {
+      const focus = sinon.stub();
+      const window = {
+        isMinimized: sinon.stub().returns(false),
+        restore: sinon.stub(),
+        moveTop: sinon.stub(),
+        showInactive: sinon.stub(),
+        focus: focus,
+        addListener: sinon.stub(),
+      };
+      return { tracked: { window } as unknown as DesktopBrowserWindow, focus };
+    }
+
+    function pendingSatellite(name: string): PendingWindow {
+      return {
+        type: 'satellite',
+        name: name,
+        mainWindow: {} as MainWindow,
+        screenX: -1,
+        screenY: -1,
+        width: 100,
+        height: 100,
+        allowExternalNavigate: false,
+      };
+    }
+
+    function pendingSecondary(name: string): PendingWindow {
+      return {
+        type: 'secondary',
+        name: name,
+        allowExternalNavigate: false,
+        showToolbar: true,
+      };
+    }
+
+    it('denies a satellite whose name is already open and activates that window', () => {
+      const app = new Application();
+      const { tracked, focus } = trackedWindow();
+      app.windowTracker.addWindow('rstudio_satellite_source', tracked);
+      app.prepareForWindow(pendingSatellite('rstudio_satellite_source'));
+
+      const result = app.windowOpening();
+
+      assert.equal(result.action, 'deny');
+      assert.isTrue(focus.calledOnce);
+      // a denied request never reaches windowCreated(), so the pending entry
+      // must not be left behind for the next unrelated window.open()
+      assert.equal(app.pendingWindows.length, 0);
+    });
+
+    it('denies a secondary window whose name is already open and activates that window', () => {
+      const app = new Application();
+      const { tracked, focus } = trackedWindow();
+      app.windowTracker.addWindow('_rstudio_help', tracked);
+      app.prepareForWindow(pendingSecondary('_rstudio_help'));
+
+      const result = app.windowOpening();
+
+      assert.equal(result.action, 'deny');
+      assert.isTrue(focus.calledOnce);
+      assert.equal(app.pendingWindows.length, 0);
+    });
+
+    it('allows a satellite with an unused name and leaves it queued for windowCreated()', () => {
+      const app = new Application();
+      app.windowTracker.addWindow('rstudio_satellite_other', trackedWindow().tracked);
+      app.prepareForWindow(pendingSatellite('rstudio_satellite_source'));
+
+      const result = app.windowOpening();
+
+      assert.equal(result.action, 'allow');
+      assert.equal(app.pendingWindows.length, 1);
+    });
+  });
+
   describe('Assorted helpers', () => {
     it('generates and stores port', () => {
       const app = new Application();

--- a/src/node/desktop/test/unit/main/application.test.ts
+++ b/src/node/desktop/test/unit/main/application.test.ts
@@ -150,7 +150,7 @@ describe('Application', () => {
       app.windowTracker.addWindow('rstudio_satellite_source', tracked);
       app.prepareForWindow(pendingSatellite('rstudio_satellite_source'));
 
-      const result = app.windowOpening();
+      const result = app.windowOpening('rstudio_satellite_source');
 
       assert.equal(result.action, 'deny');
       assert.isTrue(focus.calledOnce);
@@ -165,7 +165,7 @@ describe('Application', () => {
       app.windowTracker.addWindow('_rstudio_help', tracked);
       app.prepareForWindow(pendingSecondary('_rstudio_help'));
 
-      const result = app.windowOpening();
+      const result = app.windowOpening('_rstudio_help');
 
       assert.equal(result.action, 'deny');
       assert.isTrue(focus.calledOnce);
@@ -177,7 +177,37 @@ describe('Application', () => {
       app.windowTracker.addWindow('rstudio_satellite_other', trackedWindow().tracked);
       app.prepareForWindow(pendingSatellite('rstudio_satellite_source'));
 
-      const result = app.windowOpening();
+      const result = app.windowOpening('rstudio_satellite_source');
+
+      assert.equal(result.action, 'allow');
+      assert.equal(app.pendingWindows.length, 1);
+    });
+
+    it('drops stale entries queued ahead of the requested window', () => {
+      // Chromium reuses an already-open window of the same name without
+      // consulting us, so the entry queued for it never gets consumed; it must
+      // not deny (or configure) the next, unrelated window.open()
+      const app = new Application();
+      const { tracked, focus } = trackedWindow();
+      app.windowTracker.addWindow('rstudio_satellite_source', tracked);
+      app.prepareForWindow(pendingSatellite('rstudio_satellite_source'));
+      app.prepareForWindow(pendingSecondary('_rstudio_help'));
+
+      const result = app.windowOpening('_rstudio_help');
+
+      assert.equal(result.action, 'allow');
+      assert.isTrue(focus.notCalled);
+      assert.deepEqual(
+        app.pendingWindows.map((pending) => pending.name),
+        ['_rstudio_help'],
+      );
+    });
+
+    it('leaves the queue alone for a request with no pending entry', () => {
+      const app = new Application();
+      app.prepareForWindow(pendingSatellite('rstudio_satellite_source'));
+
+      const result = app.windowOpening('_blank');
 
       assert.equal(result.action, 'allow');
       assert.equal(app.pendingWindows.length, 1);


### PR DESCRIPTION
## Intent

`Application.windowCreated()` handles Electron's `did-create-window` event. When the pending window's name was already tracked, it raised the existing window and returned early, intending to "deny" the new window. But by the time `did-create-window` fires the `BrowserWindow` already exists, so the early return orphaned it: never configured, shown, tracked, or destroyed, and still carrying its frame name, so `activateWindow(name)` could match the orphan instead of the intended window.

## Approach

Move the duplicate-name check into `windowOpening()`, the `setWindowOpenHandler` callback, where returning `{ action: 'deny' }` stops Electron from creating the window at all. A denied request never reaches `windowCreated()`, so the pending entry is consumed there too; otherwise it would linger and attach to the next unrelated `window.open()`.

This mirrors the old Qt `WebPage::createWindow()`, which returned `nullptr` in the same situation. The GWT desktop window opener already tolerates a null `window.open()` result (`DesktopWindowOpener.showPopupBlockedMessage()` returns false), and `SatelliteManager` re-activates known satellites before opening, so this remains a last-resort guard.

## Verification

Three new unit tests in `application.test.ts` cover the satellite deny, the secondary-window deny (both activate the existing window and empty the pending queue), and the allow path leaving the pending entry queued for `windowCreated()`.

From `src/node/desktop`: `npm run lint` and `npm run typecheck` clean; `npm test` 478 passing, with only the known worktree-only `findComponents` failure (no built rsession).

No NEWS entry: the path is rarely reachable in practice since Chromium reuses same-name windows for `window.open()` from the same opener.

Fixes #18775.
