### PR TITLE
Update Electron to 43.7.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,5 +20,6 @@
 
 ### Dependencies
 - Copilot Language Server 1.544.0
+- Electron 43.7.0
 - Node.js 24.21.0 (GitHub Copilot, Posit Assistant)
 

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.5",
-        "electron": "42.11.1",
+        "electron": "43.7.0",
         "electron-mocha": "13.1.0",
         "eslint": "10.10.0",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -6017,9 +6017,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "42.11.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.11.1.tgz",
-      "integrity": "sha512-mRYYjGDRWCyU+h4FU/0ruqxL/rXc+h2VCLhTb19KHu18HCUFWQAeFS/mFwnEKT/7GQCwlIHOhHie5ICLPXW6aw==",
+      "version": "43.7.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.7.0.tgz",
+      "integrity": "sha512-m98FUehwnoo6q2D9Mr+n602Natb2CRFeKD81GhTdJlKh/Iyud0R1X8hChjpaMBLSsIX9r2ZEFnz0sdIALiO9ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -60,7 +60,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.5",
-    "electron": "42.11.1",
+    "electron": "43.7.0",
     "electron-mocha": "13.1.0",
     "eslint": "10.10.0",
     "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -100,7 +100,7 @@
     "winston-syslog": "2.7.1"
   },
   "allowScripts": {
-    "electron@42.11.1": true,
+    "electron@43.7.0": true,
     "msgpackr-extract@3.0.3": true,
     "unix-dgram@2.0.6": true
   }

--- a/src/node/desktop/scripts/postinstall.js
+++ b/src/node/desktop/scripts/postinstall.js
@@ -1,7 +1,7 @@
 /*
  * postinstall.js
  *
- * Copyright (C) 2024 by Posit Software, PBC
+ * Copyright (C) 2026 by Posit Software, PBC
  *
  * Unless you have received this program directly from Posit Software pursuant
  * to the terms of a commercial license agreement with Posit Software, then
@@ -13,6 +13,58 @@
  *
  */
 
-// this script will run after `npm i` completes
+// this script will run after `npm i` completes, and before `electron-rebuild`
+// builds our native dependencies against the Electron headers
 
-// currently not used for anything
+const fs = require('fs');
+const path = require('path');
+
+const ADDON_GYPI = path.join(__dirname, '..', 'node_modules', '@electron', 'node-gyp', 'addon.gypi');
+const DEFINE = 'V8_DEPRECATION_WARNINGS=1';
+const DEFINE_COMMENT = '# Warn when using deprecated V8 APIs.';
+
+/**
+ * Electron 43 ships V8 15, where v8::String::Value carries a class-head
+ * deprecation:
+ *
+ *     class V8_DEPRECATED("...") V8_EXPORT Value {
+ *
+ * With V8_DEPRECATION_WARNINGS defined that expands to a C++11 attribute
+ * followed by a GNU attribute, which GCC <= 12 cannot parse in either order.
+ * Our older Linux build images ship GCC 11, so every native module that
+ * includes v8.h -- msgpackr-extract, and unix-dgram by way of nan.h -- fails
+ * to build there. addon.gypi adds the define to every addon electron-rebuild
+ * builds, so dropping it there covers all of them.
+ *
+ * Remove this once the build images move to GCC 13 or later, or once the
+ * Electron headers stop mixing the two attribute syntaxes.
+ * See https://github.com/electron/electron/issues/53284.
+ */
+function removeV8DeprecationWarningsDefine() {
+  if (!fs.existsSync(ADDON_GYPI)) {
+    throw new Error(
+      `postinstall: no addon.gypi at ${ADDON_GYPI}, so the ${DEFINE} define could not be removed. ` +
+        'Run `npm install` in src/node/desktop first.',
+    );
+  }
+
+  const contents = fs.readFileSync(ADDON_GYPI, 'utf8');
+  if (!contents.includes(DEFINE)) {
+    // already removed, either by a previous run or by @electron/node-gyp itself
+    return;
+  }
+
+  const patched = contents
+    .split('\n')
+    .filter((line) => !line.includes(DEFINE) && line.trim() !== DEFINE_COMMENT)
+    .join('\n');
+
+  if (patched.includes(DEFINE)) {
+    throw new Error(`postinstall: failed to remove the ${DEFINE} define from ${ADDON_GYPI}.`);
+  }
+
+  fs.writeFileSync(ADDON_GYPI, patched);
+  console.log(`postinstall: removed the ${DEFINE} define from ${ADDON_GYPI}`);
+}
+
+removeV8DeprecationWarningsDefine();


### PR DESCRIPTION
Updates the pinned Electron version from 42.11.1 to 43.7.0, a major line bump.

Stack versions, read from the installed binary via `process.versions`:

| | 42.11.1 | 43.7.0 |
| --- | --- | --- |
| Chromium | 148.0.7778.280 | 150.0.7871.250 |
| Node.js | 24.19.0 | 24.21.0 |
| V8 | 14.8.178.38 | 15.0.245.31 |

## Why take this update

**Two Chromium majors of security fixes.** 148 to 150 pulls in everything fixed in those branches, which is the bulk of the value in any Electron bump.

**Startup work in Electron 43.** The 43.0.0 release adds Node.js startup snapshots, V8 bytecode caching for framework bundles and preload scripts, and renderer initialization changes. Desktop startup time is an area we touched separately this release (#18739); this is upstream work landing in the same path, not something measured here.

**43.7.0 fixes that touch paths we use.** A Windows crash when a file dialog is shown for a window that is being closed at the same time — RStudio routes all of its GWT-driven file dialogs through `dialog.showOpenDialog`/`showSaveDialog` in `src/main/gwt-callback.ts`. Also a Linux crash when `process.env` is written while another thread reads the environment, and a memory leak when a worker thread exits.

## Electron 43 breaking changes, checked against this codebase

- **`dialog` `defaultPath` now defaults to the Downloads folder** when not explicitly provided, instead of letting the OS pick (usually the last-visited directory). Every call site here passes `defaultPath` explicitly — `gwt-callback.ts:212`, `:271`, `:300`, `choose-r.ts:150`, `context-menu.ts:55` — so the new default never applies. "Save Image As" passes a bare filename with no directory, so its starting directory is still OS-chosen, as before.
- **`showHiddenFiles` removed from dialogs on Linux** — not used.
- **Frameless windows default to rounded corners on Linux.** The splash screen opts out explicitly (`splash-screen.ts:30`); the What's New window (`whats-new-window.ts:72`, `frame: false`) will pick up rounded corners on Linux. Cosmetic.
- **Window Controls Overlay adopts native layout on Linux** — no `titleBarOverlay` usage.
- **`NativeImage.toBitmap()` normalizes to sRGB** — no `toBitmap` usage.
- **`chrome.scripting` CSS injection follows Chrome frame matching** — no extensions are loaded.

## Native module builds on older Linux images

Electron 43 ships V8 15, where `v8::String::Value` moved its deprecation onto the class head:

```cpp
class V8_DEPRECATED(
    "Prefer using String::ValueView if you can, or string->Write to a "
    "buffer if you cannot.") V8_EXPORT Value {
```

`@electron/node-gyp`'s `addon.gypi` compiles every addon with `V8_DEPRECATION_WARNINGS=1`, so this expands to `class [[deprecated("…")]] __attribute__((visibility("default"))) Value` — a C++11 attribute mixed with a GNU attribute in a class head, which GCC <= 12 cannot parse in either order. Clang and GCC 13+ accept it, which is why the GitHub Actions builds (macOS, Windows, ubuntu-24) were green while the Jenkins jammy package build failed:

```
/var/lib/jenkins/.electron-gyp/43.7.0/include/node/v8config.h:854:20: error: expected identifier before '__attribute__'
  854 | # define V8_EXPORT __attribute__((visibility("default")))
✖ Rebuild Failed — node-gyp failed to rebuild '.../node_modules/msgpackr-extract'
```

Electron 42 carried the same declaration under `V8_DEPRECATE_SOON`, which expands to nothing because `V8_IMMINENT_DEPRECATION_WARNINGS` is not defined; 43 changed it to `V8_DEPRECATED`. Upstream report: electron/electron#53284.

Two native dependencies include `v8.h` and are affected: `msgpackr-extract` (via `net-ipc` → `msgpackr`) and `unix-dgram` (via `winston-syslog`, which `winston-logger.ts:72` uses with `protocol: 'unix'` on `/dev/log`). Both have to be built against the Electron ABI, so leaving them out of the rebuild is not an option. `desktop.node` and `dock.node` use N-API and are unaffected.

`scripts/postinstall.js` — an unused stub until now, and already the step that runs immediately before `electron-rebuild` — removes the define from `addon.gypi`, which covers every addon in one place. The cost is that third-party addon builds no longer print V8 deprecation warnings. It can be dropped once the build images reach GCC 13, or once the headers stop mixing the two attribute syntaxes.

## Testing

From `src/node/desktop`: `npm test` passes (476 passing), `npm run typecheck` passes, and `npm run lint` exits clean with 2 pre-existing `no-empty-function` warnings in `test/unit/main/session-launcher.test.ts` that this change does not touch. `npx electron-rebuild` completes against 43.7.0. `node_modules/electron/dist/version` reports 43.7.0 — the binary is fetched lazily rather than by `npm install`, so it was pulled with `npx --no-install install-electron` and checked.

`npm run package` from a plain source tree gets through file copying and native dependency preparation with Electron 43, then fails at Forge's `extendInfo: './Info.plist'` (`forge.config.js:92`): that file is generated by CMake into the build directory (`CMakeLists.txt:219`), which a standalone run does not do. The failure is independent of the Electron version. A full CMake build was not run here.


The `addon.gypi` change was verified by inspecting the generated makefiles before and after: `-DV8_DEPRECATION_WARNINGS=1` appeared 4 times across `msgpackr-extract/build/*.mk` and `unix-dgram/build/*.mk` before the change and 0 times after, with `electron-rebuild` reporting Rebuild Complete and both `.node` files rebuilt. That check ran under clang locally, so it confirms the define is gone and nothing regressed; the GCC 11 path is what the Jenkins jammy build exercises.
