### PR TITLE
e2e: keep a slow posit ai sign-in from failing the whole shard

### DIFF
--- a/e2e/rstudio/tests/auth.setup.ts
+++ b/e2e/rstudio/tests/auth.setup.ts
@@ -345,9 +345,11 @@ async function step<T>(page: Page, name: string, fn: () => Promise<T>, fatal = f
     const wrapped = `[authorize-posit] ${name} failed: ${msg} (page: ${url})`;
     // Failures at credential/authorization steps are fatal (LoginAutomationError);
     // non-credential steps stay transient so a flaky page load lets the Posit AI
-    // tests skip rather than failing the whole run. Note this classifies by
-    // step, not by error kind -- see the catch in the setup body.
-    throw fatal ? new LoginAutomationError(wrapped) : new Error(wrapped);
+    // tests skip rather than failing the whole run. A step that has already
+    // diagnosed a credential rejection itself throws LoginAutomationError, and
+    // that verdict is kept -- see the catch in the setup body.
+    const isFatal = fatal || err instanceof LoginAutomationError;
+    throw isFatal ? new LoginAutomationError(wrapped) : new Error(wrapped);
   }
 }
 
@@ -412,9 +414,36 @@ async function automateLogin(
       const passwordInput = page.locator('input[type="password"]');
       await passwordInput.waitFor({ state: 'visible' });
       await passwordInput.fill(password);
-      await page.getByRole('button', { name: /log.?in|sign.?in|continue/i }).click();
-      await page.waitForURL(/\/oauth\/device/, { timeout: 30000 });
-    }, true);
+      // noWaitAfter: click() otherwise waits for the navigation it triggers
+      // under the runner's actionTimeout (10s), which a slow redirect blew
+      // through and took the whole run down with it. Let the 30s URL wait
+      // below own that budget instead.
+      await page
+        .getByRole('button', { name: /log.?in|sign.?in|continue/i })
+        .click({ noWaitAfter: true });
+      const redirected = await page
+        .waitForURL(/\/oauth\/device/, { timeout: 30000 })
+        .then(() => true, () => false);
+      if (redirected)
+        return;
+
+      // Not redirected. A rejected password is the fatal case, and it shows
+      // up as an error message on the login page; anything else (a slow or
+      // stalled redirect) is transient and lets the Posit AI tests skip. The
+      // text patterns are deliberately narrow: ordinary login-page copy
+      // ("Wrong account?", "Try again") must not read as a rejection.
+      const rejection = page
+        .getByRole('alert')
+        .or(page.getByText(/incorrect|invalid|not recognized|does ?n.t match/i))
+        .first();
+      if (await rejection.isVisible().catch(() => false)) {
+        const rejectionText = await rejection.innerText().catch(() => '');
+        throw new LoginAutomationError(
+          `credentials rejected: ${rejectionText.trim().slice(0, 120)}`,
+        );
+      }
+      throw new Error('no redirect to /oauth/device within 30s of submitting the password');
+    });
     await step(page, 'enter user code', async () => {
       // _complete URL prefills the userCode form; navigate to the bare URI
       // for an empty form to type into.
@@ -512,12 +541,13 @@ function failIfStrict(providerLabel: string, reason: string): void {
 
 setup('authenticate Posit AI', async () => {
   // Explicit headroom above the flow's own budget: browser launch, five login
-  // steps (30s library default each on the raw chromium context -- the
-  // config's actionTimeout doesn't apply there), and the 90s token poll can
-  // legitimately exceed the global 120s test timeout. If the harness timeout
-  // fired here, the catch below would never run and every dependent test
-  // would be marked "did not run"; the withDeadline race below fails through
-  // the transient path well before this outer limit can be reached.
+  // steps (the runner applies the config's actionTimeout to contexts launched
+  // during a test, so 10s per action plus the password step's own 30s URL
+  // wait), and the 90s token poll can legitimately exceed the global 120s
+  // test timeout. If the harness timeout fired here, the catch below would
+  // never run and every dependent test would be marked "did not run"; the
+  // withDeadline race below fails through the transient path well before this
+  // outer limit can be reached.
   setup.setTimeout(240_000);
 
   const sandbox = process.env.PW_SANDBOX;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
@@ -18,7 +18,17 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@chat
   let consoleActions: ConsolePaneActions;
   let versions: EnvironmentVersions;
 
-  const PROMPT = 'Write R code that asks the user for their name and count how many letters there are in it. Use the readline command. Run the code.';
+  // Spelled out because the assistant otherwise sometimes reasons that
+  // readline() cannot work under a tool and writes the code into a source
+  // file instead of running it, and the notification never appears.
+  const PROMPT = 'Write R code that asks the user for their name with readline() and counts how many letters are in it. Run the code now with the executeCode tool; do not create or open a file.';
+
+  // The assistant's turn does not end when readline() returns: it typically
+  // reads the console back and comments on the result first, which has taken
+  // well over 30s on CI. Give that the same settle window the rest of the
+  // suite gives a turn, and size the test to hold two turns plus the readline.
+  const POST_READLINE_TURN_BUDGET_MS = 90000;
+  const TEST_TIMEOUT_MS = 300000;
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     ({ chatActions, chatPane, consoleActions, versions } = await setupPositAssistantChat(page));
@@ -29,6 +39,8 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@chat
   });
 
   test('notification appears when readline blocks, chat is unresponsive, and notification clears after input', async ({ rstudioPage: page }) => {
+    test.setTimeout(TEST_TIMEOUT_MS);
+
     // Start a fresh conversation
     await chatActions.startNewConversation();
 
@@ -82,7 +94,7 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@chat
     // isTurnIdle() rather than a raw stop-button sample: the button flickers
     // off between streaming phases, and a single hidden sample lands in that
     // gap often enough to be the flake this suite keeps hitting.
-    await expect.poll(() => chatActions.isTurnIdle(), { timeout: 30000 })
+    await expect.poll(() => chatActions.isTurnIdle(), { timeout: POST_READLINE_TURN_BUDGET_MS })
       .toBe(true);
 
     // Ask the assistant to print a Tempest quote to the console


### PR DESCRIPTION
## Intent

Two hardening changes prompted by the e2e failures on #18765, none of which were caused by that PR.

## Approach

**Auth setup (`tests/auth.setup.ts`).** The `submit password` step was marked fatal, so any error there became a `LoginAutomationError` and failed the setup project, which left every dependent test in the shard as "did not run" (333 tests on the Linux server shard). The actual failure was a slow redirect after the click, not a rejected password: `click()` waits for the navigation it triggers under the runner's `actionTimeout`, which is 10s here (the runner applies the config's `actionTimeout` to contexts launched during a test, contrary to the comment that assumed a 30s library default).

- Click with `noWaitAfter` so the existing 30s `waitForURL` owns the redirect budget.
- Classify by error kind rather than by step: the step is fatal only when the login page shows a visible rejection message (an `alert` role or narrow text such as "incorrect" / "invalid"). A stalled redirect now falls through to the transient path, and the `@ai` tests skip with that reason in the status file rather than taking the shard down.
- `step()` keeps a `LoginAutomationError` a step throws itself, so the fail-loud verdict for a real credential problem survives.

**Readline test (`readline-notification.test.ts`).** Its post-readline idle wait was the only 30s turn budget in the suite; every other wait settles for at least 60s. The assistant routinely keeps working after `readline()` returns (reads the console back, comments on the result), which is what failed on both macOS and Windows.

- Raise that wait to 90s and set the test timeout to 300s so two turns plus the readline fit.
- Spell out in the prompt that the code must be run with the executeCode tool and not written to a file, which is what the first macOS attempt did (the notification never appeared).

## Testing

- `npm run typecheck` in `e2e/rstudio` passes.
- Neither path can be exercised locally without Posit AI credentials, so verification of the live behavior is via CI on this PR (the `@ai` suite and the auth setup run there).

## Checklist

- [x] No NEWS.md entry (test-only change)
