### PR TITLE
Match chat messages by role testid, not data-message-id

### DIFF
--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -54,7 +54,18 @@ export class ChatPane extends FramePageObject {
     // input is now a contenteditable <div class="tiptap-input-editor">, not a
     // <textarea>. editor.setEditable() toggles its contenteditable attribute.
     this.chatInput = this.frame.locator('.tiptap-input-editor');
-    this.messageItem = this.frame.locator('[data-message-id]');
+    // The ChatMessage row wrapper and the MessageRenderer content div nested
+    // inside it, so most messages match twice and last() lands on the content.
+    // An allowlist, not `[data-message-id]`: that attribute marks anything tied
+    // to a message, and PA 1.4.0 (#2395) began stamping it on a per-turn footer
+    // rendered *after* the row, which made last() resolve to a "8:54 PM" cost
+    // row. Matching what a message is works against both the released assistant
+    // and the pre-release builds the gate exercises. The row wrapper stays in
+    // the list because messages that render no MessageRenderer (application
+    // events, attachment-only) have no content div to match.
+    this.messageItem = this.frame.locator(
+      '[data-testid="chat-message-user"], [data-testid="chat-message-assistant"], [data-message-id].message-content'
+    );
     // Assistant-role bubbles only. The message wrapper carries the role via an
     // inner .chat-message-assistant / .chat-message-user class (ChatMessage.tsx),
     // so this excludes the user's own prompt bubble -- letting callers match on
@@ -158,10 +169,16 @@ export class ChatPane extends FramePageObject {
     // provider blip itself, so a failed lookup reads as "not substantive"
     // rather than erroring out of the caller's retry loop.
     return await this.messageItem.last().evaluate((el) => {
-      // Each message stamps data-message-id on both the ChatMessage row
-      // wrapper and the nested MessageRenderer content div, so last() lands
-      // on the inner div and the assistant class sits on an ancestor;
-      // closest() covers that shape, querySelector() the row wrapper.
+      // last() is normally the MessageRenderer content div, with the assistant
+      // class on an ancestor; for a message that renders no MessageRenderer it
+      // is the row wrapper, with the class on a descendant. closest() covers
+      // the first shape, querySelector() the second.
+      //
+      // Scoping to the content div rather than the row is what keeps a dead
+      // turn readable: the row also holds TurnRetryCallout, whose "Retry" /
+      // "Continue" button text would count as reply content below and report
+      // an empty turn as substantive, disabling the retry this predicate exists
+      // to trigger.
       if (!el.closest('.chat-message-assistant') && !el.querySelector('.chat-message-assistant')) {
         return false;
       }

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
@@ -55,14 +55,14 @@ test.describe.serial('Conversation History', { tag: ['@ai', '@chat'] }, () => {
     await chatActions.openConversationHistory();
     await chatPane.getConversationItemByName(athenaName).first().click();
     await chatActions.closeConversationHistory();
-    const athenaMessages = chatPane.frame.locator('[data-message-id]');
+    const athenaMessages = chatPane.messageItem;
     await expect(athenaMessages.last()).toContainText('Athena', { timeout: 5000 });
 
     // Open history again for Aphrodite
     await chatActions.openConversationHistory();
     await chatPane.getConversationItemByName(aphroditeName).first().click();
     await chatActions.closeConversationHistory();
-    const aphroditeMessages = chatPane.frame.locator('[data-message-id]');
+    const aphroditeMessages = chatPane.messageItem;
     await expect(aphroditeMessages.last()).toContainText('Aphrodite', { timeout: 5000 });
 
     // Open history and delete Artemis conversation


### PR DESCRIPTION
### Intent

The Posit Assistant chat suite fails on every platform against PA 1.4.0. The release gate
run for 1.4.0 ([34528484543](https://github.com/rstudio/rstudio/actions/runs/34528484543))
failed six tests on Linux, macOS and Windows, on every retry:

- `chat-messaging.test.ts:50` multi-turn conversation
- `chat-guardrails.test.ts:206` write to project directory is allowed
- `chat-user-skills.test.ts:243` both custom skills are discovered
- `conversation-history.test.ts:23` history preserves and restores conversations
- `detachable-sidebar.test.ts:29` conversation continuity across detach and reattach
- `shiny-app-r.test.ts:110` create and run R Shiny tip calculator

`ChatPane.messageItem` was `[data-message-id]`. That is an application attribute the
assistant stamps on anything tied to a message, not a marker for messages, and PA 1.4.0
(posit-dev/assistant#2395) began stamping it on a per-turn footer rendered as a sibling
*after* the message row. `messageItem.last()` therefore resolved to a cost and timing row:

```
Expected substring: "23"
Received string:    "8:54 PM"
locator resolved to <div class="-mt-3 mb-4" data-testid="turn-footer-row" data-message-id="…">
```

The same shift made `isLastMessageSubstantive()` read those footers as non-substantive,
so `askAssistant` reported the failures as `the provider appears to be dropping turns
mid-stream` — which sent triage after a provider problem that did not exist.

### Approach

Match the two hooks that mark message content — the `ChatMessage` row wrapper, which
carries the role testid, and the `MessageRenderer` content div nested inside it:

```ts
'[data-testid="chat-message-user"], [data-testid="chat-message-assistant"], [data-message-id].message-content'
```

Both hooks are present unchanged in the released assistant and in 1.4.0, so the matched
set is identical against the current GA build and the suite runs against either. Being an
allowlist keyed on what a message is, rather than on a shared id, it also does not admit
whatever gets decorated with `data-message-id` next.

Both clauses are load-bearing:

- The content div carries the assertion. Scoping to the row instead would pull in
  `TurnRetryCallout`, whose "Retry" / "Continue" button text counts as reply content in
  `isLastMessageSubstantive()` — reporting a genuinely dead turn as substantive and
  disabling the retry that predicate exists to trigger.
- The row wrapper keeps the count complete. Messages that render no `MessageRenderer`
  (application events, attachment-only) have no content div, and would drop out of
  `getMessageCount()` so `waitForResponse` waits on growth that never arrives.

`conversation-history.test.ts` built the same locator inline twice, bypassing the page
object; those now use `chatPane.messageItem` so there is one definition to keep correct.

### Automated Tests

This is a change to the test suite. Verified by driving Chromium against fixtures of both
DOM shapes, built from `ChatMessage.tsx`, `MessageRenderer.tsx` and `ConversationViewport.tsx`
at the released and 1.4.0 tags, using the selector read back out of the edited file:

| Scenario | before | after |
| --- | --- | --- |
| Released assistant, normal turn | count 4, last = reply content | unchanged: count 4, last = reply content |
| 1.4.0, normal turn | count 5, last = `"8:54 PM"` footer | count 4, last = reply content |
| 1.4.0, dead turn with retry callout | last = footer | last = empty content, substantive `false`, retry still fires |
| 1.4.0, application-event message | last = footer | last = row, message still counted |

`npm run typecheck` in `e2e/rstudio` passes.

Not yet confirmed by a live suite run — that needs the gate, which can run against the
1.4.0 build already published to the test manifest.

### QA Notes

None. Test-only change; no product code is touched.

### Documentation

None required.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
