### PR TITLE
Tolerate U+200E in the skill-selection e2e assertion

### DIFF
--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -326,6 +326,10 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@chat', '@serial'] }, 
     const lastMessage = chatPane.messageItem.last();
     const responseText = await lastMessage.innerText();
 
-    expect(responseText).toMatch(new RegExp(`skill:\\s*${USER_SKILL_NAME}`));
+    // Assistant 1.4.0+ prefixes every tool-call caption with U+200E (LEFT-TO-RIGHT
+    // MARK) so an rtl-truncated file path keeps its leading slash on the left. JS
+    // `\s` does not cover U+200E, so match it explicitly; the class also accepts
+    // the bare whitespace that 1.3.1 and earlier emit.
+    expect(responseText).toMatch(new RegExp(`skill:[\\s\\u200e]*${USER_SKILL_NAME}`));
   });
 });


### PR DESCRIPTION
`chat-user-skills.test.ts` asserts that the assistant emits `skill: custom-code-review` when it selects a user-level skill. The assertion matched `skill:\s*<name>`.

Posit Assistant 1.4.0 began prefixing every tool-call caption with U+200E (LEFT-TO-RIGHT MARK), so that an rtl-truncated file path keeps its leading slash on the left — posit-dev/assistant `d6d3901e7`. The rendered text is now `skill:\n‎custom-code-review`.

JavaScript's `\s` spans ` - ` and does not include U+200E, so the assertion failed against a string that is visually identical to what it expected. It failed deterministically on Windows, Linux and macOS, on both attempts, in the PA 1.4.1 release gate ([run 34546046306](https://github.com/rstudio/rstudio/actions/runs/34546046306)).

## Change

Match the mark explicitly with `skill:[\s‎]*<name>`.

The class also accepts bare whitespace, so the test passes against both released versions:

| pattern | PA 1.3.1 (no LRM) | PA 1.4.1 (LRM) |
| --- | --- | --- |
| `skill:\s*<name>` | pass | **fail** |
| `skill:[\s‎]*<name>` | pass | pass |

## Scope

Only this assertion is affected. The other regex assertions in the Posit Assistant suite (`chat-guardrails.test.ts`, `chat-guardrails-paths.test.ts`) match R console output rather than chat text, and `chat-user-skills.test.ts:261` uses a substring match, which a leading mark does not disturb.

`npm run typecheck` passes in `e2e/rstudio`.

## Not covered here

The same gate run also failed `restart-under-agent.test.ts:102` on Windows (`page.waitForFunction` 30s timeout during a project open/close cycle, with `Agent process exited with status 1` in the rsession log). That is a separate issue and is not addressed by this PR.