### PR TITLE
Don't prompt to save the workspace right after a session restart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - ([#12379](https://github.com/rstudio/rstudio/issues/12379)): Customized editor keyboard shortcuts (e.g. Remove Word Left) now also apply to the Console input.
 
 ### Fixed
+- ([#18784](https://github.com/rstudio/rstudio/issues/18784)): Fixed an issue where quitting, closing a project, or switching projects shortly after a session restart prompted to save the workspace image even when Save workspace was set to Never.
 - ([#18760](https://github.com/rstudio/rstudio/issues/18760)): Fixed an issue where long R version names in Global Options > General could push the R version selector outside the dialog.
 - ([#18735](https://github.com/rstudio/rstudio/issues/18735)): Fixed an issue on Windows where RStudio failed to start when the command prompt was disabled by Group Policy.
 - ([#18744](https://github.com/rstudio/rstudio/issues/18744)): RStudio Desktop now uses link-based file locks by default on macOS and Linux, matching RStudio Server, so sessions from both editions sharing a data directory or a project on a network drive no longer mistake each other's live locks for stale ones.

--- a/e2e/rstudio/tests/projects/close_project_after_open.test.ts
+++ b/e2e/rstudio/tests/projects/close_project_after_open.test.ts
@@ -4,7 +4,7 @@ import { useSuiteSandbox } from '@utils/sandbox';
 import { getPref } from '@utils/commands';
 
 // Closing a project immediately after opening one must not prompt to save the
-// workspace image when save_workspace is "never" (rstudio/rstudio#18394).
+// workspace image when save_workspace is "never" (rstudio/rstudio#18784).
 //
 // The session reports its save action two ways: in the client_init SessionInfo
 // payload, and asynchronously through save_action_changed. The client used to

--- a/e2e/rstudio/tests/projects/close_project_after_open.test.ts
+++ b/e2e/rstudio/tests/projects/close_project_after_open.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { createAndOpenProject, closeProjectIfOpen } from '@utils/project';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { getPref } from '@utils/commands';
+
+// Closing a project immediately after opening one must not prompt to save the
+// workspace image when save_workspace is "never" (rstudio/rstudio#18394).
+//
+// The session reports its save action two ways: in the client_init SessionInfo
+// payload, and asynchronously through save_action_changed. The client used to
+// have only the event, defaulting to "ask" until one arrived, and the session's
+// first event for a new session was the same "ask" placeholder. So a close
+// issued before the first event batch was delivered prompted "Save workspace
+// image to .../.RData?" -- with nothing to answer the modal, the close never
+// completed and project.isActive() stayed true.
+//
+// This test leaves no gap between the open and the close: no console command
+// runs in the new session, so nothing forces the R-side detect-changes pass
+// that produced the corrected event. A regression fails inside
+// closeProjectIfOpen, which blocks on project.isActive() === false.
+test.describe('Close project immediately after open', { tag: ['@projects'] }, () => {
+  const sandbox = useSuiteSandbox();
+
+  test('closes without prompting to save the workspace', async ({ rstudioPage: page }) => {
+    // Two session restarts, each of which can be slow on a loaded CI worker.
+    test.setTimeout(180000);
+
+    // The prompt this guards against is only wrong because the preference says
+    // never (set in fixtures/base-prefs.jsonc). Assert it rather than assume
+    // it: under "ask" the dialog is correct behaviour and the test would be
+    // checking nothing.
+    expect(
+      await getPref(page, 'save_workspace'),
+      'harness default save_workspace should be never',
+    ).toBe('never');
+
+    await createAndOpenProject(page, sandbox.dir, 'close_after_open');
+    await closeProjectIfOpen(page);
+
+    expect(
+      await page.evaluate(() => window.rstudio?.project?.isActive()),
+      'project should be closed',
+    ).toBe(false);
+  });
+});

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -241,15 +241,20 @@ export async function closeProjectIfOpen(page: Page): Promise<void> {
       { timeout: TIMEOUTS.sessionRestart, polling: 100 },
     );
   } catch (err) {
-    const blocking = await page
-      .locator('div.gwt-DialogBox:visible')
-      .first()
-      .innerText()
-      .catch(() => '');
+    const blocking = (
+      await page
+        .locator('div.gwt-DialogBox:visible')
+        .first()
+        .innerText()
+        .catch(() => '')
+    )
+      .replace(/\s+/g, ' ')
+      .trim();
     if (blocking)
       throw new Error(
         `closeProjectIfOpen: project still active; a modal dialog is blocking the close: ` +
-          `${JSON.stringify(blocking.replace(/\s+/g, ' ').trim())}`,
+          `${JSON.stringify(blocking)}`,
+        { cause: err },
       );
     throw err;
   }

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -230,11 +230,29 @@ export async function closeProjectIfOpen(page: Page): Promise<void> {
   // workbench rebuilds; `project.isActive()` returns false only once the new
   // SessionInfo has propagated. Polling on both signals catches the case
   // where the bridge is from the previous (project-bound) session.
-  await page.waitForFunction(
-    () => window.rstudio?.project?.isActive() === false,
-    null,
-    { timeout: TIMEOUTS.sessionRestart, polling: 100 },
-  );
+  // A modal that the close itself raised (e.g. "Save workspace image to
+  // .../.RData?") blocks the close indefinitely, and every wait above is
+  // satisfiable by the still-open project's console -- so this wait is where
+  // that lands, as a bare 30s timeout. Name the dialog in the failure instead.
+  try {
+    await page.waitForFunction(
+      () => window.rstudio?.project?.isActive() === false,
+      null,
+      { timeout: TIMEOUTS.sessionRestart, polling: 100 },
+    );
+  } catch (err) {
+    const blocking = await page
+      .locator('div.gwt-DialogBox:visible')
+      .first()
+      .innerText()
+      .catch(() => '');
+    if (blocking)
+      throw new Error(
+        `closeProjectIfOpen: project still active; a modal dialog is blocking the close: ` +
+          `${JSON.stringify(blocking.replace(/\s+/g, ' ').trim())}`,
+      );
+    throw err;
+  }
 
   // Dismiss any modal error dialog that surfaced while the new workbench
   // was initializing -- e.g. a Files-pane refresh racing the rsession's

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -27,6 +27,7 @@
 #include "modules/SessionAssistant.hpp"
 #include "modules/SessionBreakpoints.hpp"
 #include "modules/SessionDependencyList.hpp"
+#include "modules/SessionDirty.hpp"
 #include "modules/SessionRAddins.hpp"
 #include "modules/SessionErrors.hpp"
 #include "modules/SessionFind.hpp"
@@ -316,6 +317,9 @@ void handleClientInit(const boost::function<void()>& initFunction,
    
    // get current console language
    sessionInfo["console_language"] = modules::reticulate::isReplActive() ? "Python" : "R";
+
+   // the save action a quit or project close would take right now
+   sessionInfo["save_action"] = modules::dirty::saveAction();
 
    // resumed
    sessionInfo["resumed"] = resumed;

--- a/src/cpp/session/modules/SessionDirty.cpp
+++ b/src/cpp/session/modules/SessionDirty.cpp
@@ -122,9 +122,7 @@ void handleSaveActionChanged()
 void checkForSaveActionChanged()
 {
    // compute current save action
-   int currentSaveAction = r::session::imageIsDirty() ?
-                                 module_context::saveWorkspaceAction() :
-                                 r::session::kSaveActionNoSave;
+   int currentSaveAction = saveAction();
 
    // compare and fire event if necessary
    if (s_lastSaveAction != currentSaveAction)
@@ -152,7 +150,12 @@ void onResume(const Settings& settings)
 
 void onClientInit()
 {
-   // enque save action changed
+   // enque save action changed. compute the action first: s_lastSaveAction
+   // still holds its 'ask' placeholder until the first detect-changes pass
+   // runs, and publishing that told the client to prompt for an unsaved
+   // workspace image on a quit or project close issued before the pass --
+   // even with save_workspace set to never.
+   s_lastSaveAction = saveAction();
    handleSaveActionChanged();
 }
  
@@ -164,6 +167,13 @@ void onDetectChanges(module_context::ChangeSource source)
 
 } // anonymous namespace
  
+int saveAction()
+{
+   return r::session::imageIsDirty() ?
+             module_context::saveWorkspaceAction() :
+             r::session::kSaveActionNoSave;
+}
+
 Error initialize()
 {         
    // add suspend handler

--- a/src/cpp/session/modules/SessionDirty.hpp
+++ b/src/cpp/session/modules/SessionDirty.hpp
@@ -27,6 +27,12 @@ namespace session {
 namespace modules { 
 namespace dirty {
 
+// The save action the session would take if it exited right now, as one of the
+// r::session::kSaveAction* values. Reported in SessionInfo so a quit or project
+// close issued before the first save_action_changed event reaches the client
+// still uses the real action rather than the client's 'ask' default.
+int saveAction();
+
 core::Error initialize();
 
 } // namespace dirty

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -50,6 +50,7 @@ import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.LastChanceSaveEvent;
 import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.model.SessionOpener;
 import org.rstudio.studio.client.workbench.model.UnsavedChangesItem;
 import org.rstudio.studio.client.workbench.model.UnsavedChangesTarget;
@@ -84,7 +85,8 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
                           Binder binder,
                           TerminalHelper terminalHelper,
                           Provider<JobManager> pJobManager,
-                          Provider<SessionOpener> pSessionOpener)
+                          Provider<SessionOpener> pSessionOpener,
+                          Provider<Session> pSession)
    {
       // save references
       server_ = server;
@@ -96,6 +98,7 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
       terminalHelper_ = terminalHelper;
       pJobManager_ = pJobManager;
       pSessionOpener_ = pSessionOpener;
+      pSession_ = pSession;
       
       // bind to commands
       binder.bind(commands, this);
@@ -179,7 +182,7 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
    {
       Command handleUnsaved = () -> {
          // handle unsaved editor changes
-         handleUnsavedChanges(saveAction_.getAction(), caption, allowCancel, forceSaveAll,
+         handleUnsavedChanges(saveAction().getAction(), caption, allowCancel, forceSaveAll,
                pSource_.get(), workbenchContext_, globalEnvTarget_, quitContext);
       };
 
@@ -407,6 +410,29 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
    {
       saveAction_ = event.getAction();
    }
+
+   /**
+    * The session's current save action.
+    *
+    * SaveActionChangedEvent is asynchronous, so a quit or project close issued
+    * soon after a session restart can run before the first one arrives -- on a
+    * loaded machine the new session's first event batch can take seconds. Fall
+    * back to the action client_init reported, which is already correct by the
+    * time the workbench is interactive; defaulting to "ask" here prompted to
+    * save the workspace image even with save_workspace set to never, and in
+    * that state the close never completes until someone answers the dialog.
+    */
+   private SaveAction saveAction()
+   {
+      if (saveAction_ != null)
+         return saveAction_;
+
+      SessionInfo sessionInfo = pSession_.get().getSessionInfo();
+      SaveAction reported = sessionInfo != null ? sessionInfo.getSaveAction() : null;
+
+      // prompting is the conservative choice when the session hasn't told us
+      return reported != null ? reported : SaveAction.saveAsk();
+   }
    
    @Override
    public void onHandleUnsavedChanges(HandleUnsavedChangesEvent event)
@@ -487,7 +513,7 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
          {
             terminalHelper_.warnBusyTerminalBeforeCommand(() ->
             {
-               boolean saveChanges = saveAction_.getAction() != SaveAction.NOSAVE;
+               boolean saveChanges = saveAction().getAction() != SaveAction.NOSAVE;
                SuspendOptions options = SuspendOptions.createSaveMinimal(saveChanges);
                eventBus_.fireEvent(new SuspendAndRestartEvent(options));
             }, constants_.restartRCaption(), constants_.terminalJobTerminatedQuestion(),
@@ -756,7 +782,9 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
       return suspendingAndRestarting_;
    }
    
-   private SaveAction saveAction_ = SaveAction.saveAsk();
+   // null until the session publishes a SaveActionChangedEvent; read through
+   // saveAction() so the value client_init delivered is used in the meantime
+   private SaveAction saveAction_ = null;
    private boolean isQuitting_ = false;
    private boolean suspendingAndRestarting_ = false;
 
@@ -770,5 +798,6 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
    private final TerminalHelper terminalHelper_;
    private final Provider<JobManager> pJobManager_;
    private final Provider<SessionOpener> pSessionOpener_;
+   private final Provider<Session> pSession_;
    private static final StudioClientApplicationConstants constants_ = GWT.create(StudioClientApplicationConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.application.ApplicationUtils;
 import org.rstudio.studio.client.application.model.RVersionsInfo;
+import org.rstudio.studio.client.application.model.SaveAction;
 import org.rstudio.studio.client.application.model.SessionInitOptions;
 import org.rstudio.studio.client.common.compilepdf.model.CompilePdfState;
 import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
@@ -84,7 +85,18 @@ public class SessionInfo extends JavaScriptObject
    public final native String getPrompt() /*-{
       return this.prompt;
    }-*/;
-   
+
+   /**
+    * The save action a quit or project close would take right now, as one of
+    * the {@link SaveAction} constants, or null if the session did not report
+    * one. The session also publishes this through SaveActionChangedEvent, but
+    * that event is asynchronous -- callers that can run before the first one
+    * arrives must start from this value.
+    */
+   public final native SaveAction getSaveAction() /*-{
+      return (this.save_action == null) ? null : { action: this.save_action };
+   }-*/;
+
    public final native JsArray<RnwWeave> getRnwWeaveTypes() /*-{
       return this.rnw_weave_types;
    }-*/;


### PR DESCRIPTION
### Intent

Fixes #18784.

A quit, project close, or project switch issued shortly after a session restart prompted "Save workspace image to `<path>/.RData`?" even with `save_workspace` set to `never`.

The client learned the save action only from the asynchronous `save_action_changed` event, and `ApplicationQuit.saveAction_` was initialized to `SaveAction.saveAsk()` until one arrived. The action was not part of `SessionInfo`, so there was nothing else to fall back on. On the session side, `s_lastSaveAction` starts at `kSaveActionAsk` and `onClientInit` published that placeholder as-is; only the first `onDetectChanges` pass recomputed it. Every session therefore emitted `save_action_changed {action: -1}` followed by `{action: 0}`, and a close issued before that batch reached the client used "ask".

### Approach

`SessionInfo` now carries `save_action`, which `client_init` delivers before the workbench is interactive, and `onClientInit` computes the action before publishing so the event carries the real value too. Both read one function, `modules::dirty::saveAction()`, so the two channels cannot disagree.

On the client, `saveAction_` starts null and is read through a `saveAction()` accessor that falls back to the value `client_init` reported. "Ask" is now used only when the session has reported nothing at all.

### Impact

For an interactive user this was one dismissible prompt, and every path that reaches it is user-initiated (quit, restart/update RStudio, switch R version, new project, close project, switch projects) -- nothing background can trigger it. A secondary effect was silent rather than dismissible: inside the same window, Restart R derived `saveChanges` from `SAVEASK != NOSAVE`, so a restart could write `.RData` with `save_workspace` set to `never`.

Unattended automation cannot answer the modal, so the close never completed. That is how this surfaced: `e2e/rstudio/tests/panes/posit-assistant-chat/restart-under-agent.test.ts` timed out after 30s waiting on `window.rstudio.project.isActive() === false` while the prompt sat unanswered, on six consecutive Windows runs of the Posit Assistant release gate.

This is not a regression. `saveAction_ = SaveAction.saveAsk()` dates to 2011 (`4993b7e7e3d`) and `s_lastSaveAction = kSaveActionAsk` to 2013 (`57a301581a1`), and both are present unchanged on `rel-autumn-hawkbit`. What changed was the delivery time of the first event batch, not RStudio.

### Verification

Added `e2e/rstudio/tests/projects/close_project_after_open.test.ts`, which opens a project and closes it with no console command in between, so nothing forces the R-side detect-changes pass. It asserts `save_workspace` is `never` first, so it cannot pass vacuously under `ask`, and asserts that `closeProjectIfOpen` did not have to dismiss the save prompt -- that helper sweeps the prompt away for the other project tests, so without this assertion a regression would go unnoticed. It is untagged, so it runs in normal PR CI rather than only in the release gate.

Verified on a Windows dev desktop build:

- Every `client_init` reports `save_action=0`, across the project open and the following close.
- The only `save_action_changed` events emitted are `{action: 0}`; the `-1` placeholder is gone. Pre-fix CI payloads show `-1` then `0` in every session.
- `tests/projects/` passes in full (24 passed).

The sub-second window depends on a loaded CI worker, so the original failure was not reproducible locally; the checks above verify the mechanism instead. Final confirmation is a gate run.

`closeProjectIfOpen` also now names the modal blocking a close instead of reporting a bare `waitForFunction` timeout.

### Follow-up

`DesktopHooks.getSaveAction()` has the same event-only staleness, but it is exported to JS and uncalled -- a Qt-desktop leftover. Left alone here rather than deleting an exported symbol.

