### PR TITLE
Start the Dock's New RStudio Window with no project

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - ([#12379](https://github.com/rstudio/rstudio/issues/12379)): Customized editor keyboard shortcuts (e.g. Remove Word Left) now also apply to the Console input.
 
 ### Fixed
+- ([#15669](https://github.com/rstudio/rstudio/issues/15669)): Fixed an issue on macOS where the Dock icon's "New RStudio Window" command opened the project that was already open in the current window, instead of starting a session with no project.
 - ([#18760](https://github.com/rstudio/rstudio/issues/18760)): Fixed an issue where long R version names in Global Options > General could push the R version selector outside the dialog.
 - ([#18735](https://github.com/rstudio/rstudio/issues/18735)): Fixed an issue on Windows where RStudio failed to start when the command prompt was disabled by Group Policy.
 - ([#18744](https://github.com/rstudio/rstudio/issues/18744)): RStudio Desktop now uses link-based file locks by default on macOS and Linux, matching RStudio Server, so sessions from both editions sharing a data directory or a project on a network drive no longer mistake each other's live locks for stale ones.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 - ([#12379](https://github.com/rstudio/rstudio/issues/12379)): Customized editor keyboard shortcuts (e.g. Remove Word Left) now also apply to the Console input.
 
 ### Fixed
-- ([#15669](https://github.com/rstudio/rstudio/issues/15669)): Fixed an issue on macOS where the Dock icon's "New RStudio Window" command opened the project that was already open in the current window, instead of starting a session with no project.
+- ([#15669](https://github.com/rstudio/rstudio/issues/15669)): Fixed an issue on macOS where the Dock icon's "New RStudio Window" command opened the project that was already open in the current window. The new window now starts with no project, in the default working directory.
 - ([#18760](https://github.com/rstudio/rstudio/issues/18760)): Fixed an issue where long R version names in Global Options > General could push the R version selector outside the dialog.
 - ([#18735](https://github.com/rstudio/rstudio/issues/18735)): Fixed an issue on Windows where RStudio failed to start when the command prompt was disabled by Group Policy.
 - ([#18744](https://github.com/rstudio/rstudio/issues/18744)): RStudio Desktop now uses link-based file locks by default on macOS and Linux, matching RStudio Server, so sessions from both editions sharing a data directory or a project on a network drive no longer mistake each other's live locks for stale ones.

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -31,7 +31,6 @@ import org.rstudio.core.client.dom.Clipboard;
 import org.rstudio.core.client.dom.DocumentEx;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
-import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ModalDialogTracker;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -242,14 +241,6 @@ public class Application implements ApplicationEventHandlers
 
             // set session info
             session_.setSessionInfo(sessionInfo);
-            
-            // set project path for desktop
-            if (Desktop.isDesktop())
-            {
-               FileSystemItem projectDir = sessionInfo.getActiveProjectDir();
-               if (projectDir != null)
-                  Desktop.getFrame().setProjectDirectory(projectDir.getPath());
-            }
             
             // load MathJax
             MathJaxLoader.ensureMathJaxLoaded();

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -155,7 +155,6 @@ public interface DesktopFrame extends JavaScriptPassthrough
    
    void setPendingQuit(int pendingQuit, CommandWithArg<Void> callback);
    void setPendingProject(String projectFilePath);
-   void setProjectDirectory(String projectDirectory);
    void launchSession(boolean reload);
    
    void openProjectInNewWindow(String projectFilePath);

--- a/src/node/desktop/src/core/r-user-data.ts
+++ b/src/node/desktop/src/core/r-user-data.ts
@@ -17,6 +17,10 @@ export const kRStudioInitialWorkingDir = 'RS_INITIAL_WD';
 export const kRStudioInitialEnvironment = 'RS_INITIAL_ENV';
 export const kRStudioInitialProject = 'RS_INITIAL_PROJECT';
 
+// value for kRStudioInitialProject asking the session to start with no project;
+// matches kProjectNone in the session (RSessionContext.hpp)
+export const kProjectNone = 'none';
+
 export enum SessionType {
   SessionTypeDesktop = 0,
   SessionTypeServer = 1,

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -57,7 +57,6 @@ export interface AppState {
   client?: Client;
   eventBus?: TypedEventEmitter<EventBusTypes>;
   argsManager: ArgsManager;
-  projectDirectory?: string;
   stateDirIssues: UserDirIssue[];
 }
 

--- a/src/node/desktop/src/main/application-launch.ts
+++ b/src/node/desktop/src/main/application-launch.ts
@@ -25,6 +25,9 @@ import { app } from 'electron';
 export interface LaunchRStudioOptions {
   projectFilePath?: string;
   workingDirectory?: string;
+
+  // start the new session with no project, even if the working directory contains one
+  noProject?: boolean;
 }
 
 export function resolveProjectFile(projectDir: string): string {
@@ -80,9 +83,11 @@ export class ApplicationLaunch {
     setenv(kRStudioInitialWorkingDir, workingDir);
 
     // resolve project file, if any
-    const projectFile = options.projectFilePath ?? resolveProjectFile(workingDir);
-    if (existsSync(projectFile)) {
-      setenv(kRStudioInitialProject, projectFile);
+    if (!options.noProject) {
+      const projectFile = options.projectFilePath ?? resolveProjectFile(workingDir);
+      if (existsSync(projectFile)) {
+        setenv(kRStudioInitialProject, projectFile);
+      }
     }
 
     // run it

--- a/src/node/desktop/src/main/application-launch.ts
+++ b/src/node/desktop/src/main/application-launch.ts
@@ -17,7 +17,7 @@ import path from 'path';
 import { spawn } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
 import { setenv, unsetenv } from '../core/environment';
-import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../core/r-user-data';
+import { kProjectNone, kRStudioInitialProject, kRStudioInitialWorkingDir } from '../core/r-user-data';
 import { MainWindow } from './main-window';
 import { isAutomated } from './utils';
 import { app } from 'electron';
@@ -26,7 +26,7 @@ export interface LaunchRStudioOptions {
   projectFilePath?: string;
   workingDirectory?: string;
 
-  // start the new session with no project, even if the working directory contains one
+  // start the new session with no project, in the user's default working directory
   noProject?: boolean;
 }
 
@@ -73,22 +73,26 @@ export class ApplicationLaunch {
       argv.push('--automation-agent');
     }
 
-    // resolve working directory
-    let workingDir = app.getPath('home');
-    if (options.workingDirectory != null) {
-      workingDir = options.workingDirectory;
-    } else if (options.projectFilePath != null) {
-      workingDir = path.dirname(options.projectFilePath);
-    }
-    setenv(kRStudioInitialWorkingDir, workingDir);
-
-    // this instance may have been started by opening a project, which leaves the
-    // variable set in our own environment; clear it so it can't leak to the new session
+    // this instance may have been started by opening a project or a file, which leaves these
+    // variables set in our own environment; clear them so they can't leak to the new session
     unsetenv(kRStudioInitialProject);
+    unsetenv(kRStudioInitialWorkingDir);
 
-    // resolve project file, if any
-    if (!options.noProject) {
-      const projectFile = options.projectFilePath ?? resolveProjectFile(workingDir);
+    if (options.noProject) {
+      // ask for no project explicitly, so the session doesn't restore the last one; with no
+      // working directory of our own the session uses the user's default working directory
+      setenv(kRStudioInitialProject, kProjectNone);
+    } else {
+      // resolve working directory; callers give us either a directory or a project file
+      const workingDir =
+        options.workingDirectory ??
+        (options.projectFilePath === undefined ? undefined : path.dirname(options.projectFilePath));
+      if (workingDir !== undefined) {
+        setenv(kRStudioInitialWorkingDir, workingDir);
+      }
+
+      // resolve project file, if any
+      const projectFile = options.projectFilePath ?? (workingDir === undefined ? '' : resolveProjectFile(workingDir));
       if (existsSync(projectFile)) {
         setenv(kRStudioInitialProject, projectFile);
       }

--- a/src/node/desktop/src/main/application-launch.ts
+++ b/src/node/desktop/src/main/application-launch.ts
@@ -82,6 +82,10 @@ export class ApplicationLaunch {
     }
     setenv(kRStudioInitialWorkingDir, workingDir);
 
+    // this instance may have been started by opening a project, which leaves the
+    // variable set in our own environment; clear it so it can't leak to the new session
+    unsetenv(kRStudioInitialProject);
+
     // resolve project file, if any
     if (!options.noProject) {
       const projectFile = options.projectFilePath ?? resolveProjectFile(workingDir);

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -582,7 +582,9 @@ export class Application implements AppState {
         {
           label: i18next.t('applicationTs.newRstudioWindow'),
           click: () => {
-            this.appLaunch?.launchRStudio({ workingDirectory: appState().projectDirectory });
+            // start in the project's directory, but don't open the project itself;
+            // this command is for starting a new, separate session (#15669)
+            this.appLaunch?.launchRStudio({ workingDirectory: appState().projectDirectory, noProject: true });
           },
         },
       ]);

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -582,9 +582,9 @@ export class Application implements AppState {
         {
           label: i18next.t('applicationTs.newRstudioWindow'),
           click: () => {
-            // start in the project's directory, but don't open the project itself;
-            // this command is for starting a new, separate session (#15669)
-            this.appLaunch?.launchRStudio({ workingDirectory: appState().projectDirectory, noProject: true });
+            // this command starts a new, separate session: no project, and the user's
+            // default working directory rather than anything from this window (#15669)
+            this.appLaunch?.launchRStudio({ noProject: true });
           },
         },
       ]);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -779,10 +779,6 @@ export class GwtCallback extends EventEmitter {
       this.pendingQuit = pendingQuit;
     });
 
-    ipcMain.on('desktop_set_project_directory', (event, projectDirectory) => {
-      appState().projectDirectory = resolveAliasedPath(projectDirectory);
-    });
-
     ipcMain.on('desktop_open_project_in_new_window', (event, projectFilePath) => {
       this.mainWindow.launchRStudio({
         projectFilePath: resolveAliasedPath(projectFilePath),

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -410,10 +410,6 @@ export function getDesktopBridge() {
         .catch((error) => reportIpcError('setPendingQuit', error));
     },
 
-    setProjectDirectory: (projectDirectory: string) => {
-      ipcRenderer.send('desktop_set_project_directory', projectDirectory);
-    },
-
     openFile: (path: string) => {
       if (!path) {
         return;

--- a/src/node/desktop/test/unit/main/application-launch.test.ts
+++ b/src/node/desktop/test/unit/main/application-launch.test.ts
@@ -17,17 +17,45 @@ import { describe } from 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import childProcess, { ChildProcess } from 'child_process';
 import { app } from 'electron';
 
+import { getenv } from '../../../src/core/environment';
+import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../../../src/core/r-user-data';
 import { ApplicationLaunch, resolveProjectFile } from '../../../src/main/application-launch';
 import { MainWindow } from '../../../src/main/main-window';
 import { createSinonStubInstance } from '../unit-utils';
 
 describe('ApplicationLaunch', () => {
+  const tempDirs: string[] = [];
+
   afterEach(() => {
     sinon.restore();
+    while (tempDirs.length) {
+      fs.rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+    }
   });
+
+  function projectDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rstudio-application-launch-test-'));
+    tempDirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'test.Rproj'), '');
+    return dir;
+  }
+
+  // the relaunched instance picks up its initial project and working directory
+  // from the environment, which is only set for the duration of the spawn call
+  function captureLaunchEnv(): { project: string; workingDir: string } {
+    const launchEnv = { project: '', workingDir: '' };
+    sinon.stub(childProcess, 'spawn').callsFake(() => {
+      launchEnv.project = getenv(kRStudioInitialProject);
+      launchEnv.workingDir = getenv(kRStudioInitialWorkingDir);
+      return { unref: sinon.stub() } as unknown as ChildProcess;
+    });
+    return launchEnv;
+  }
 
   it('static init returns new instance', () => {
     const appLaunch = ApplicationLaunch.init();
@@ -58,6 +86,26 @@ describe('ApplicationLaunch', () => {
       app.commandLine.removeSwitch('automation-agent');
     }
     assert.include(spawnStub.secondCall.args[1] as string[], '--automation-agent');
+  });
+
+  it('launchRStudio opens the project found in the working directory', () => {
+    const launchEnv = captureLaunchEnv();
+    const dir = projectDir();
+
+    ApplicationLaunch.init().launchRStudio({ workingDirectory: dir });
+
+    assert.equal(launchEnv.project, path.join(dir, 'test.Rproj'));
+    assert.equal(launchEnv.workingDir, dir);
+  });
+
+  it('launchRStudio starts without a project when noProject is requested', () => {
+    const launchEnv = captureLaunchEnv();
+    const dir = projectDir();
+
+    ApplicationLaunch.init().launchRStudio({ workingDirectory: dir, noProject: true });
+
+    assert.isEmpty(launchEnv.project);
+    assert.equal(launchEnv.workingDir, dir);
   });
 
   it('Resolve Empty Project File Path', () => {

--- a/src/node/desktop/test/unit/main/application-launch.test.ts
+++ b/src/node/desktop/test/unit/main/application-launch.test.ts
@@ -23,7 +23,7 @@ import childProcess, { ChildProcess } from 'child_process';
 import { app } from 'electron';
 
 import { getenv, setenv } from '../../../src/core/environment';
-import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../../../src/core/r-user-data';
+import { kProjectNone, kRStudioInitialProject, kRStudioInitialWorkingDir } from '../../../src/core/r-user-data';
 import { ApplicationLaunch, resolveProjectFile } from '../../../src/main/application-launch';
 import { MainWindow } from '../../../src/main/main-window';
 import { createSinonStubInstance, restore, saveAndClear } from '../unit-utils';
@@ -107,27 +107,29 @@ describe('ApplicationLaunch', () => {
     assert.equal(launchEnv.workingDir, dir);
   });
 
-  it('launchRStudio starts without a project when noProject is requested', () => {
+  it('launchRStudio asks for no project, and no working directory, when noProject is requested', () => {
     const launchEnv = captureLaunchEnv();
-    const dir = projectDir();
 
-    ApplicationLaunch.init().launchRStudio({ workingDirectory: dir, noProject: true });
+    ApplicationLaunch.init().launchRStudio({ noProject: true });
 
-    assert.isEmpty(launchEnv.project);
-    assert.equal(launchEnv.workingDir, dir);
+    // the session needs an explicit "none" so it doesn't restore the last project, and no
+    // working directory of ours so it uses the user's default working directory
+    assert.equal(launchEnv.project, kProjectNone);
+    assert.isEmpty(launchEnv.workingDir);
   });
 
-  it('launchRStudio ignores an inherited initial project when noProject is requested', () => {
+  it('launchRStudio ignores an inherited project and working directory when noProject is requested', () => {
     const launchEnv = captureLaunchEnv();
     const dir = projectDir();
 
     // set when this instance was itself started by opening a project
     setenv(kRStudioInitialProject, path.join(dir, 'test.Rproj'));
+    setenv(kRStudioInitialWorkingDir, dir);
 
-    ApplicationLaunch.init().launchRStudio({ workingDirectory: dir, noProject: true });
+    ApplicationLaunch.init().launchRStudio({ noProject: true });
 
-    assert.isEmpty(launchEnv.project);
-    assert.equal(launchEnv.workingDir, dir);
+    assert.equal(launchEnv.project, kProjectNone);
+    assert.isEmpty(launchEnv.workingDir);
   });
 
   it('Resolve Empty Project File Path', () => {

--- a/src/node/desktop/test/unit/main/application-launch.test.ts
+++ b/src/node/desktop/test/unit/main/application-launch.test.ts
@@ -22,16 +22,25 @@ import path from 'path';
 import childProcess, { ChildProcess } from 'child_process';
 import { app } from 'electron';
 
-import { getenv } from '../../../src/core/environment';
+import { getenv, setenv } from '../../../src/core/environment';
 import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../../../src/core/r-user-data';
 import { ApplicationLaunch, resolveProjectFile } from '../../../src/main/application-launch';
 import { MainWindow } from '../../../src/main/main-window';
-import { createSinonStubInstance } from '../unit-utils';
+import { createSinonStubInstance, restore, saveAndClear } from '../unit-utils';
 
 describe('ApplicationLaunch', () => {
   const tempDirs: string[] = [];
+  const launchEnvVars: Record<string, string> = {
+    [kRStudioInitialProject]: '',
+    [kRStudioInitialWorkingDir]: '',
+  };
+
+  beforeEach(() => {
+    saveAndClear(launchEnvVars);
+  });
 
   afterEach(() => {
+    restore(launchEnvVars);
     sinon.restore();
     while (tempDirs.length) {
       fs.rmSync(tempDirs.pop() as string, { recursive: true, force: true });
@@ -101,6 +110,19 @@ describe('ApplicationLaunch', () => {
   it('launchRStudio starts without a project when noProject is requested', () => {
     const launchEnv = captureLaunchEnv();
     const dir = projectDir();
+
+    ApplicationLaunch.init().launchRStudio({ workingDirectory: dir, noProject: true });
+
+    assert.isEmpty(launchEnv.project);
+    assert.equal(launchEnv.workingDir, dir);
+  });
+
+  it('launchRStudio ignores an inherited initial project when noProject is requested', () => {
+    const launchEnv = captureLaunchEnv();
+    const dir = projectDir();
+
+    // set when this instance was itself started by opening a project
+    setenv(kRStudioInitialProject, path.join(dir, 'test.Rproj'));
 
     ApplicationLaunch.init().launchRStudio({ workingDirectory: dir, noProject: true });
 

--- a/src/node/desktop/test/unit/main/application.test.ts
+++ b/src/node/desktop/test/unit/main/application.test.ts
@@ -15,13 +15,18 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
+import sinon from 'sinon';
 
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-import { restore, saveAndClear } from '../unit-utils';
+import { Menu } from 'electron';
+
+import { createSinonStubInstance, restore, saveAndClear } from '../unit-utils';
 import { Application, collectStateDirIssues } from '../../../src/main/application';
+import { ApplicationLaunch } from '../../../src/main/application-launch';
+import { appState, clearApplicationSingleton, setApplication } from '../../../src/main/app-state';
 import { NullLogger, setLogger } from '../../../src/core/logger';
 import { clearCoreSingleton } from '../../../src/core/core-state';
 import { randomString } from '../../../src/main/utils';
@@ -89,6 +94,41 @@ describe('Application', () => {
       assert.lengthOf(issues, 1);
       assert.strictEqual(issues[0].directory, logDir);
       assert.isNotEmpty(issues[0].message);
+    });
+  });
+
+  describe('Dock menu', () => {
+    beforeEach(() => {
+      clearApplicationSingleton();
+    });
+    afterEach(() => {
+      sinon.restore();
+      clearApplicationSingleton();
+    });
+
+    it('new window starts in the project directory, without opening the project', function () {
+      if (process.platform !== 'darwin') {
+        this.skip();
+      }
+
+      const projectDirectory = path.join(os.tmpdir(), 'some-project');
+      const application = new Application();
+      setApplication(application);
+      appState().projectDirectory = projectDirectory;
+
+      const appLaunch = createSinonStubInstance(ApplicationLaunch);
+      application.appLaunch = appLaunch;
+
+      const buildFromTemplate = sinon.spy(Menu, 'buildFromTemplate');
+      application.setDockMenu();
+
+      // the menu item's click handler ignores the arguments Electron passes it
+      const newWindowItem = buildFromTemplate.firstCall.args[0][0];
+      (newWindowItem.click as unknown as () => void)();
+
+      assert.isTrue(
+        appLaunch.launchRStudio.calledOnceWithExactly({ workingDirectory: projectDirectory, noProject: true }),
+      );
     });
   });
 

--- a/src/node/desktop/test/unit/main/application.test.ts
+++ b/src/node/desktop/test/unit/main/application.test.ts
@@ -26,7 +26,7 @@ import { Menu } from 'electron';
 import { createSinonStubInstance, restore, saveAndClear } from '../unit-utils';
 import { Application, collectStateDirIssues } from '../../../src/main/application';
 import { ApplicationLaunch } from '../../../src/main/application-launch';
-import { appState, clearApplicationSingleton, setApplication } from '../../../src/main/app-state';
+import { clearApplicationSingleton, setApplication } from '../../../src/main/app-state';
 import { NullLogger, setLogger } from '../../../src/core/logger';
 import { clearCoreSingleton } from '../../../src/core/core-state';
 import { randomString } from '../../../src/main/utils';
@@ -106,15 +106,13 @@ describe('Application', () => {
       clearApplicationSingleton();
     });
 
-    it('new window starts in the project directory, without opening the project', function () {
+    it('new window opens with no project', function () {
       if (process.platform !== 'darwin') {
         this.skip();
       }
 
-      const projectDirectory = path.join(os.tmpdir(), 'some-project');
       const application = new Application();
       setApplication(application);
-      appState().projectDirectory = projectDirectory;
 
       const appLaunch = createSinonStubInstance(ApplicationLaunch);
       application.appLaunch = appLaunch;
@@ -126,9 +124,7 @@ describe('Application', () => {
       const newWindowItem = buildFromTemplate.firstCall.args[0][0];
       (newWindowItem.click as unknown as () => void)();
 
-      assert.isTrue(
-        appLaunch.launchRStudio.calledOnceWithExactly({ workingDirectory: projectDirectory, noProject: true }),
-      );
+      assert.isTrue(appLaunch.launchRStudio.calledOnceWithExactly({ noProject: true }));
     });
   });
 


### PR DESCRIPTION
On macOS, the Dock icon's "New RStudio Window" command passed the current window's project directory as the new session's working directory. The session then opened the `.Rproj` file found there, so the new window came up with the same project as the window it was launched from.

The command now asks the session for no project explicitly, and sends no working directory, so the new window starts in the user's Default working directory (Global Options > General > Basic) with no project open. That is where the Qt versions of RStudio started these windows; those versions reopened the project as well, by falling through to "Restore most recently opened project at startup".

Two related changes:

- `launchRStudio()` clears `RS_INITIAL_PROJECT` and `RS_INITIAL_WD` before setting up the new session's environment. An instance started by opening a project keeps those set for the life of the session -- only a session restart clears them -- so they would otherwise be inherited by the spawned window.
- The project directory the front end reported to the desktop existed only to give this command a working directory, and is removed.

### Verification

Unit tests cover the launch options and the Dock menu item's handler. The Dock menu itself needs a person to click it:

1. Start RStudio and open a project. Wait 30 seconds, so the project is recorded as the last project.
2. Right-click the Dock icon and choose "New RStudio Window".
3. The new window opens with no project, in the Default working directory.

I also confirmed the session behavior directly, with a custom Default working directory and a recorded last project: the session starts with no project and honors the preference.

Addresses #15669