### PR TITLE
Fix Posit Assistant failing to start in a second RStudio instance on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 - ([#14363](https://github.com/rstudio/rstudio/issues/14363)): Fixed an issue where hexadecimal literals with binary exponents (e.g. `0x1p3`), fractions, uppercase `0X` prefixes, or an imaginary suffix were reported as parse errors
 - ([#18717](https://github.com/rstudio/rstudio/issues/18717)): Fixed an issue where the diagnostics system reported a spurious parse error for indexed numeric literals, e.g. `1[TRUE]`
 - ([#18722](https://github.com/rstudio/rstudio/issues/18722)): Fixed an issue where the diagnostics system reported "unexpected end of document" for R scripts ending with a semicolon
+- ([#18787](https://github.com/rstudio/rstudio/issues/18787)): Fixed an issue on Windows where Posit Assistant failed to start in a second RStudio instance with "A Posit Assistant update is in progress".
 
 ### Dependencies
 - Copilot Language Server 1.544.0

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -6455,11 +6455,16 @@ install_lock::InstallLock& installLock()
    // (it can be empty for dev/automation-launched sessions); the uuid
    // supplies the per-process uniqueness. Leftover files from dead
    // processes are stale-cleaned by the next mutator.
-   static const std::string ownerId =
-      module_context::activeSession().id().empty()
-         ? core::system::generateUuid(false)
-         : module_context::activeSession().id() + "-" +
-              core::system::generateUuid(false);
+   //
+   // Computed in a lambda rather than a conditional expression directly in
+   // the static's initializer: MSVC in C++20 mode initializes
+   // `static const std::string x = cond ? f() : g() + f();` to an empty
+   // string, which named every session's lock file ".lock" (#18787).
+   static const std::string ownerId = []() {
+      std::string sessionId = module_context::activeSession().id();
+      std::string uuid = core::system::generateUuid(false);
+      return sessionId.empty() ? uuid : sessionId + "-" + uuid;
+   }();
    static install_lock::InstallLock instance(
       xdg::userDataDir().completePath(chat_constants::kPositAiLocksDirName),
       ownerId);

--- a/src/cpp/session/modules/chat/ChatInstallLock.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.cpp
@@ -142,6 +142,19 @@ Error InstallLock::acquireInUse(Component component, uint64_t* pToken)
 {
    *pToken = 0;
 
+   // An empty owner id would name this session's lock file ".lock", a path
+   // every other session with the same defect shares, and the resulting
+   // contention would read as an update in progress (#18787). Refuse
+   // instead so the defect surfaces as a real error.
+   if (ownerId_.empty())
+   {
+      return systemError(
+         boost::system::errc::invalid_argument,
+         "The Posit Assistant install lock has no owner id; the session "
+         "lock file cannot be named",
+         ERROR_LOCATION);
+   }
+
    if (mutationActive_)
    {
       return systemError(

--- a/src/cpp/session/modules/chat/ChatInstallLock.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.cpp
@@ -376,6 +376,11 @@ bool InstallLock::mutationInProgress() const
    return mutationActive_;
 }
 
+const std::string& InstallLock::ownerId() const
+{
+   return ownerId_;
+}
+
 FilePath InstallLock::installLockPath() const
 {
    return locksDir_.completePath(kInstallLockFileName);

--- a/src/cpp/session/modules/chat/ChatInstallLock.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.hpp
@@ -92,11 +92,13 @@ public:
                   boost::none);
 
    // Acquires the in-use lock (first component takes the file lock; the
-   // second just marks itself held). Fails while this process's own mutation
-   // is active: a re-entrant start dispatched during the mutation must not
-   // launch from the directory being swapped, and the install.lock probe in
-   // acquireInUseForStart() cannot catch it (our own advisory lock does not
-   // conflict in-process), so this in-process check is the only guard.
+   // second just marks itself held). Fails if the owner id is empty (the
+   // lock file would be named ".lock" and shared by every session, #18787).
+   // Fails while this process's own mutation is active: a re-entrant start
+   // dispatched during the mutation must not launch from the directory being
+   // swapped, and the install.lock probe in acquireInUseForStart() cannot
+   // catch it (our own advisory lock does not conflict in-process), so this
+   // in-process check is the only guard.
    //
    // On success *pToken receives a generation token identifying this holder;
    // on failure it receives 0. Tokens are never 0, so callers may use 0 as a

--- a/src/cpp/session/modules/chat/ChatInstallLock.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.hpp
@@ -153,6 +153,7 @@ public:
    // transitions via mutationInProgress() (in-process flag only; it never
    // probes the file — self-probing an advisory lock would release it).
    bool mutationInProgress() const;
+   const std::string& ownerId() const;
    core::FilePath installLockPath() const;
    core::FilePath sessionLocksDir() const;
 

--- a/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
@@ -13,18 +13,10 @@
  *
  */
 
-// Link-based locks are unsupported on Windows (FileLock forces advisory
-// there), and these tests rely on link-based semantics for cross-instance
-// exclusion within one process (POSIX fcntl advisory locks never conflict
-// in-process). The lock primitive itself is covered on Windows by
-// Win32FileLockTests.cpp; InstallLock's token/component state machine is
-// platform-independent and exercised here on POSIX.
-#ifndef _WIN32
-
 #include "ChatInstallLock.hpp"
 
-#include <sys/wait.h>
-#include <unistd.h>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -34,8 +26,22 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 
+#include "../SessionChat.hpp"
+
 using namespace rstudio::core;
 using namespace rstudio::session::modules::chat::install_lock;
+
+// Link-based locks are unsupported on Windows (FileLock forces advisory
+// there), and the tests in this block rely on link-based semantics for
+// cross-instance exclusion within one process (POSIX fcntl advisory locks
+// never conflict in-process). The lock primitive itself is covered on
+// Windows by Win32FileLockTests.cpp; InstallLock's token/component state
+// machine is platform-independent and exercised here on POSIX. The tests
+// after the block run everywhere.
+#ifndef _WIN32
+
+#include <sys/wait.h>
+#include <unistd.h>
 
 namespace {
 
@@ -695,3 +701,68 @@ TEST_F(ChatInstallLock, AcquireInUseForStartFailsClosedWhenInstallLockUninspecta
 } // anonymous namespace
 
 #endif // !_WIN32
+
+namespace {
+
+// Single-instance tests over a temp locks directory; advisory locks so they
+// run on every platform.
+class ChatInstallLockOwner : public testing::Test
+{
+protected:
+   void SetUp() override
+   {
+      FileLock::initialize();
+      ASSERT_FALSE(FilePath::tempFilePath(tempPath_));
+      locksDir_ = tempPath_.completePath("locks");
+   }
+
+   void TearDown() override
+   {
+      tempPath_.removeIfExists();
+   }
+
+   std::vector<std::string> sessionLockFileNames(const InstallLock& lock)
+   {
+      std::vector<FilePath> children;
+      Error error = lock.sessionLocksDir().getChildren(children);
+      EXPECT_FALSE(error);
+      std::vector<std::string> names;
+      for (const FilePath& child : children)
+         names.push_back(child.getFilename());
+      return names;
+   }
+
+   FilePath tempPath_;
+   FilePath locksDir_;
+};
+
+TEST_F(ChatInstallLockOwner, OwnerIdNamesTheSessionLockFile)
+{
+   InstallLock lock(locksDir_, "971bc367-abc123", FileLock::LOCKTYPE_ADVISORY);
+
+   uint64_t token = 0;
+   std::string userMessage;
+   ASSERT_FALSE(lock.acquireInUseForStart(
+      InstallLock::Component::ChatBackend, &token, &userMessage));
+   EXPECT_NE(token, 0u);
+
+   std::vector<std::string> names = sessionLockFileNames(lock);
+   ASSERT_EQ(names.size(), 1u);
+   EXPECT_EQ(names[0], "971bc367-abc123.lock");
+
+   lock.releaseInUse(InstallLock::Component::ChatBackend, token);
+   EXPECT_TRUE(sessionLockFileNames(lock).empty());
+}
+
+// The production accessor derives the owner id from the session id and a
+// per-process uuid. MSVC in C++20 mode initialized the previous form of
+// that static (a conditional expression) to an empty string, so every
+// Windows session locked "sessions/.lock" and the second instance refused
+// to start (#18787). Constructing the singleton touches no files.
+TEST(ChatInstallLockProduction, OwnerIdIsNotEmpty)
+{
+   EXPECT_FALSE(
+      rstudio::session::modules::chat::installLock().ownerId().empty());
+}
+
+} // anonymous namespace

--- a/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
@@ -754,6 +754,24 @@ TEST_F(ChatInstallLockOwner, OwnerIdNamesTheSessionLockFile)
    EXPECT_TRUE(sessionLockFileNames(lock).empty());
 }
 
+TEST_F(ChatInstallLockOwner, EmptyOwnerIdIsRefusedNotSharedAsDotLock)
+{
+   InstallLock lock(locksDir_, "", FileLock::LOCKTYPE_ADVISORY);
+
+   uint64_t token = 0;
+   std::string userMessage;
+   Error error = lock.acquireInUseForStart(
+      InstallLock::Component::ChatBackend, &token, &userMessage);
+   EXPECT_TRUE(error);
+   EXPECT_EQ(token, 0u);
+   EXPECT_FALSE(lock.inUseHeld());
+
+   // A missing owner id is a defect, not an update in progress.
+   EXPECT_NE(userMessage.find("Unable to verify"), std::string::npos);
+   EXPECT_EQ(userMessage.find("update is in progress"), std::string::npos);
+   EXPECT_FALSE(lock.sessionLocksDir().completePath(".lock").exists());
+}
+
 // The production accessor derives the owner id from the session id and a
 // per-process uuid. MSVC in C++20 mode initialized the previous form of
 // that static (a conditional expression) to an empty string, so every


### PR DESCRIPTION
### Intent

Fixes #18787.

On Windows, every RStudio session named its Posit Assistant "in use" lock file `pai/locks/sessions/.lock`, so a second instance collided with the first and Posit Assistant refused to start with "A Posit Assistant update is in progress".

The owner id that names the file is a function-local `static const std::string` initialized by a conditional expression. MSVC 19.51 in C++20 mode (which the Windows build uses) initializes that static to an empty string; the same code is correct in C++17 mode, as a non-static local, or when the initializer is wrapped in a lambda. The static was introduced by #18573, which is why 2026.08 is unaffected.

### Approach

- Compute the owner id inside an immediately-invoked lambda with plain locals.
- `InstallLock::acquireInUse` refuses an empty owner id with a real error, so a regression surfaces as "Unable to verify the Posit Assistant installation state" instead of silently sharing one file and reporting an update in progress.
- Expose `InstallLock::ownerId()` as a test seam.

### Automated Tests

The lock tests were entirely `#ifndef _WIN32`, so nothing exercised owner-path naming on Windows. This PR moves the tests' common includes out of the POSIX-only block and adds three tests that compile everywhere:

- the session lock file is named `<owner>.lock`
- an empty owner id is refused without creating `.lock`
- the production accessor's owner id is non-empty (fails on the previous initializer under MSVC, passes with the fix)

### QA Notes

Verified on Windows 11 with the local dev build; QA notes added to the issue.

### Documentation

None; no user-facing behavior beyond the bug fix. NEWS entry added.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
