### PR TITLE
e2e: harden five flaky specs from the cross-platform run

### DIFF
--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -39,8 +39,13 @@ export class SourcePaneActions {
   }
 
   async closeSourceAndDeleteFile(fileName: string): Promise<void> {
-    await executeCommand(this.page, 'saveAllSourceDocs');
-    await sleep(1000);
+    // No saveAllSourceDocs here: the file is deleted two lines down, so
+    // saving it changes nothing -- but it prompts Save File for any dirty
+    // Untitled tab, and that modal's glass panel blocks every later click
+    // (it broke the markdown HTML-preview spec on all four platforms).
+    // resetSourcePane reverts dirty file-backed tabs instead, which needs no
+    // dialog.
+    //
     // resetSourcePane closes every tab except a single Untitled placeholder,
     // so the source pane never transits through the zero-tab HIDE state
     // (#17738) and the next test starts from a known good state. The previous

--- a/e2e/rstudio/pages/modals.page.ts
+++ b/e2e/rstudio/pages/modals.page.ts
@@ -81,3 +81,53 @@ export async function dismissBlockingModals(page: Page): Promise<string[]> {
 
   return dismissed;
 }
+
+/**
+ * Dismiss the "Save workspace image to <path>?" prompt that a session quit --
+ * Close Project, or a project switch -- can put up, choosing "Don't Save".
+ * Resolves to true if a prompt was dismissed.
+ *
+ * The prompt is a race, not a preference problem. The e2e sessions all run
+ * with `save_workspace: never`, but the client reaches that value only when
+ * the backend pushes a SaveActionChangedEvent; until then ApplicationQuit's
+ * `saveAction_` holds its SaveAction.saveAsk() default, and a quit decided in
+ * that window prompts. Tests that open and close projects back to back (e.g.
+ * restart-under-agent) quit sessions that are seconds old, so they land in it.
+ *
+ * Polls rather than waiting a fixed interval: the prompt appears only after
+ * the quit's unsaved-changes round trip, and in the common no-prompt case the
+ * quit proceeds instead -- which flips `window.rstudio.ready` to false (or
+ * tears the execution context down entirely, in Server mode where the page
+ * navigates). Either is the signal to stop looking, so a session that is not
+ * going to prompt costs one poll, not the timeout.
+ */
+export async function dismissSaveWorkspacePrompt(page: Page, timeout: number = 15000): Promise<boolean> {
+  const deadline = Date.now() + timeout;
+
+  // The same selector set the fixtures use for the startup sweep. It isn't
+  // scoped to this dialog's caption, but the only modal that can be up in
+  // the moment between dispatching a quit and the quit starting is the
+  // quit's own prompt.
+  const dontSave = page.locator(
+    "button:has-text('Don\\'t Save'), button:has-text('Do not Save'), " + NO_BTN,
+  ).first();
+
+  for (;;) {
+    if (await dontSave.isVisible().catch(() => false)) {
+      await dontSave.click();
+      console.log('dismissSaveWorkspacePrompt: chose "Don\'t Save" on the quit prompt');
+      return true;
+    }
+
+    // `ready === true` means the workbench is still up, i.e. the quit has not
+    // begun; anything else (false, missing bridge, destroyed context) means it
+    // has, so no prompt is coming.
+    const quitStarted = await page
+      .evaluate(() => window.rstudio?.ready !== true)
+      .catch(() => true);
+    if (quitStarted || Date.now() >= deadline)
+      return false;
+
+    await sleep(100);
+  }
+}

--- a/e2e/rstudio/pages/source_pane.page.ts
+++ b/e2e/rstudio/pages/source_pane.page.ts
@@ -31,6 +31,7 @@ export class SourcePane extends PageObject {
   public chunkImage: Locator;
   public statusBarCompletionReceived: Locator;
   public statusBarCompletionPending: Locator;
+  public statusBarNoCompletions: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -72,6 +73,10 @@ export class SourcePane extends PageObject {
     // Shown while a code-completion request is in flight (COMPLETION_REQUESTED).
     // Its presence means a response may still land and re-render ghost text.
     this.statusBarCompletionPending = this.footerTable.locator('.gwt-Label', { hasText: 'Waiting for completions' });
+    // Terminal state for a request that came back empty (assistantNoCompletions
+    // in EditorsTextConstants). Nothing retries on its own from here, so a test
+    // waiting on ghost text must re-request rather than keep waiting.
+    this.statusBarNoCompletions = this.footerTable.locator('.gwt-Label', { hasText: 'No completions available' });
   }
 }
 

--- a/e2e/rstudio/tests/panes/console/console_editor_keybindings.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_editor_keybindings.test.ts
@@ -119,11 +119,23 @@ test.describe.serial('Console honors custom editor keybindings', () => {
     const input = consoleActions.consolePane.consoleInput;
     await input.click({ force: true });
     await waitForConsoleFocus(page);
-    await setConsoleInput(page, 'gamma delta');
-    await expect.poll(() => consoleActions.consolePane.consoleInputValue()).toBe('gamma delta');
 
-    await page.keyboard.press(NEW_SHORTCUT);
-    await expect.poll(() => consoleActions.consolePane.consoleInputValue()).toBe('gamma ');
+    // `ready` says R's deferred init is done; it says nothing about the
+    // editor bindings, which EditorCommandManager loads on EditorLoadedEvent
+    // and applies only once an async read of editor_bindings.json returns.
+    // A single press can therefore land before the rebinding exists and be
+    // swallowed, so retry the whole set-press-assert block: the retry is what
+    // waits for the load, and the assertion still fails if the binding never
+    // reaches the console.
+    await expect(async () => {
+      await setConsoleInput(page, 'gamma delta');
+      await expect.poll(() => consoleActions.consolePane.consoleInputValue()).toBe('gamma delta');
+
+      await page.keyboard.press(NEW_SHORTCUT);
+      await expect
+        .poll(() => consoleActions.consolePane.consoleInputValue(), { timeout: 2000 })
+        .toBe('gamma ');
+    }).toPass({ timeout: 20000 });
 
     await setConsoleInput(page, '');
   });

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -6,7 +6,7 @@ import { AssistantOptionsActions } from '@actions/assistant_options.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { SourcePane } from '@pages/source_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { resetSourcePaneState, setPref } from '@utils/commands';
+import { executeCommand, resetSourcePaneState, setPref } from '@utils/commands';
 import { requireAiCredentials } from '@utils/ai-credentials';
 
 for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
@@ -60,6 +60,43 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         await page.keyboard.press('Escape');
         await sleep(500);
         console.log('  Dismissed autocomplete popup (pre-ghost-text)');
+      }
+    };
+
+    // Wait for ghost text, re-requesting when the assistant answers with
+    // nothing.
+    //
+    // An automatic request that comes back empty is a terminal state: the
+    // status bar reads "<provider>: No completions available." and nothing
+    // re-asks, so a plain toBeVisible() burns the full ghost-text budget
+    // waiting for a suggestion that is never coming. That is a live model
+    // talking, not a bug -- it declines this context some of the time, and
+    // when it does it tends to do so on every platform at once, which is how
+    // one empty answer shows up as four "flaky" rows in a CI report.
+    //
+    // assistantRequestCompletions is the explicit re-ask (Request Completions
+    // in the menu). The assertion still fails if nothing ever arrives.
+    const expectGhostText = async (page: Page, timeout = TIMEOUTS.ghostText) => {
+      const deadline = Date.now() + timeout;
+      for (;;) {
+        const remaining = Math.max(deadline - Date.now(), 1000);
+        try {
+          await expect(sourcePane.ghostText.first()).toBeVisible({
+            timeout: Math.min(remaining, 10000),
+          });
+          return;
+        } catch (err) {
+          if (Date.now() >= deadline)
+            throw err;
+          if (await sourcePane.statusBarNoCompletions.isVisible().catch(() => false)) {
+            console.log('  No completions available -- re-requesting');
+            // Don't let a momentarily-disabled command replace the real
+            // diagnostic; the loop's own failure is the one worth reporting.
+            await executeCommand(page, 'assistantRequestCompletions').catch((e) =>
+              console.log(`  re-request skipped: ${e}`),
+            );
+          }
+        }
       }
     };
 
@@ -118,7 +155,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
 
       await typeTriggerOnNewLine(page, 'x <- func');
 
-      await expect(sourcePane.ghostText.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
+      await expectGhostText(page);
 
       const ghostTextParts = await sourcePane.ghostText.allTextContents();
       const ghostTextContent = ghostTextParts.join('');
@@ -428,7 +465,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
 
       await typeTriggerOnNewLine(page, 'x <- func');
 
-      await expect(sourcePane.ghostText.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
+      await expectGhostText(page);
       console.log('  Ghost text visible — pressing Escape');
 
       // Press Escape until the suggestion is gone AND no completion request is
@@ -465,7 +502,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
 
       await typeTriggerOnNewLine(page, 'x <- func');
 
-      await expect(sourcePane.ghostText.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
+      await expectGhostText(page);
       console.log('  Ghost text visible — moving cursor away');
 
       // Moving the cursor away from the completion point should dismiss the
@@ -672,7 +709,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       await typeTriggerOnNewLine(page, 'x <- calc');
 
       // Wait for ghost text to confirm a real suggestion arrived
-      await expect(sourcePane.ghostText.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
+      await expectGhostText(page);
       const ghostParts = await sourcePane.ghostText.allTextContents();
       console.log('  Ghost text: "' + ghostParts.join('') + '"');
 

--- a/e2e/rstudio/tests/panes/editor/source_pane_reset.test.ts
+++ b/e2e/rstudio/tests/panes/editor/source_pane_reset.test.ts
@@ -1,0 +1,49 @@
+// resetToUntitled must hand back a CLEAN untitled placeholder.
+//
+// The placeholder is shared state: resetSourcePaneState keeps one Untitled tab
+// open so the source pane never transits the zero-tab HIDE state (#17738), and
+// every spec in a worker inherits whatever the previous one left in it. Before
+// this was fixed, SourceColumnManager reused the existing untitled doc without
+// looking at its dirty flag -- revertUnsavedTargets only reverts file-backed
+// editors -- so a spec that typed into the placeholder (e.g. ggplot_pipe_insert
+// setting editor content directly) left that text behind. The next spec to save
+// all documents then got a modal Save File prompt for the pathless doc, and the
+// prompt's glass panel blocked every subsequent click: the markdown
+// HTML-preview spec failed this way on all four platforms at once, with the
+// misleading symptom "console input did not hold focus".
+
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { AceEditor } from '@pages/ace_editor.page';
+
+test.describe('Source pane reset', () => {
+  let consoleActions: ConsolePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    await consoleActions.resetSourcePane();
+  });
+
+  test('a dirty Untitled placeholder is replaced, not reused', async ({ rstudioPage: page }) => {
+    // Dirty the placeholder the way a spec would: write into its editor and
+    // leave it unsaved.
+    const editor = new AceEditor(page, '');
+    await editor.setValue('ggplot(mtcars, aes(wt, mpg)) + geom_point()');
+    await expect
+      .poll(() => page.evaluate(() => window.rstudio?.documents.active()?.dirty ?? null))
+      .toBe(true);
+
+    await consoleActions.resetSourcePane();
+
+    // Still a single untitled tab -- the replacement must not leave the dirty
+    // one behind, and must not empty the pane on the way through.
+    const tabs = page.locator("[class*='rstudio_source_panel'] [role='tab']");
+    await expect(tabs).toHaveCount(1);
+
+    const active = await page.evaluate(() => window.rstudio?.documents.active() ?? null);
+    expect(active).not.toBeNull();
+    expect(active?.path).toBeNull();
+    expect(active?.dirty).toBe(false);
+    expect(await editor.getValue()).toBe('');
+  });
+});

--- a/e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts
+++ b/e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts
@@ -10,6 +10,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
 import { SourcePane } from '@pages/source_pane.page';
 import { clearPref, executeCommand, setPref } from '@utils/commands';
+import { TIMEOUTS } from '@utils/constants';
 import {
   CODE_TAB,
   CODE_EDITING_PANEL,
@@ -64,6 +65,24 @@ function vimMappingRegistered(page: Page, keys: string): Promise<boolean> {
   }, keys);
 }
 
+// newSourceDoc only dispatches the command: the document is created over an
+// RPC and its editor laid out afterwards. Clicking straight away can land on
+// the outgoing document's ace_content, which is still in the DOM but no
+// longer rendered -- "Element is not visible", even with force (force skips
+// the actionability checks, not the scroll-into-view a zero-box element
+// fails). Wait for the new editor to be both active and painted.
+async function waitForNewEditor(page: Page, sourcePane: SourcePane): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const doc = window.rstudio?.documents.active() ?? null;
+      return doc !== null && doc.path === null;
+    },
+    null,
+    { timeout: TIMEOUTS.fileOpen, polling: 50 },
+  );
+  await expect(sourcePane.contentPane).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+}
+
 test.describe('Vimrc keybindings', () => {
   test('mappings from ~/.rstudio-vimrc apply when the pref is enabled', async ({
     rstudioPage: page,
@@ -82,6 +101,7 @@ test.describe('Vimrc keybindings', () => {
       // open a new document; attaching the Vim keyboard handler triggers the
       // vimrc load
       await executeCommand(page, 'newSourceDoc');
+      await waitForNewEditor(page, sourcePane);
       await expect
         .poll(() => vimMappingRegistered(page, 'jk'), {
           message: 'expected the vimrc mapping to be registered',
@@ -130,6 +150,7 @@ test.describe('Vimrc keybindings', () => {
       // Vim keybindings first, with the load pref still disabled
       await setPref(page, 'editor_keybindings', 'vim');
       await executeCommand(page, 'newSourceDoc');
+      await waitForNewEditor(page, sourcePane);
 
       // focus the editor so the mid-session load path has a Vim editor to
       // apply against, then flip the pref: the mapping should appear without

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -498,8 +498,14 @@ export async function resetSourcePaneState(page: Page): Promise<void> {
 
 /**
  * Wait until a resetSourcePaneState dispatch has actually settled: the active
- * document is the kept Untitled (path === null) AND exactly one source tab
- * remains across all columns.
+ * document is the kept Untitled (path === null), it is clean, AND exactly one
+ * source tab remains across all columns.
+ *
+ * The clean check matters because the kept Untitled is shared across specs: a
+ * dirty one raises a modal Save File prompt the next time anything saves all
+ * documents, blocking every later click. SourceColumnManager only reuses a
+ * clean untitled doc, so a dirty one here means the fresh replacement has not
+ * landed yet.
  *
  * resetToUntitled dispatches a GWT event whose handler reverts dirty targets,
  * then closes every tab except a kept Untitled in an async CPS chain of
@@ -519,7 +525,7 @@ export async function waitForSourcePaneReset(page: Page, timeout = 10000): Promi
   await page.waitForFunction(
     () => {
       const doc = window.rstudio?.documents.active() ?? null;
-      if (doc === null || doc.path !== null) return false;
+      if (doc === null || doc.path !== null || doc.dirty) return false;
       // Count source tabs across all source columns. The DocTabLayoutPanel
       // wrapper tags its root with class `rstudio_source_panel`, and each
       // open document renders one `[role="tab"]` child of the panel's tablist.

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -7,6 +7,7 @@ import {
   CONSOLE_OUTPUT,
 } from '../pages/console_pane.page';
 import { executeCommand, openProject } from './commands';
+import { dismissSaveWorkspacePrompt } from '../pages/modals.page';
 import { sleep, TIMEOUTS } from './constants';
 import { assertAbsolutePath } from './paths';
 
@@ -199,6 +200,10 @@ export async function createAndOpenProject(
  * triggers RStudio's "R session is currently busy. Are you sure you want to
  * quit?" confirmation dialog and hangs the test.
  *
+ * A close is a session quit, so it can raise the "Save workspace image?"
+ * prompt before anything else happens; dismissSaveWorkspacePrompt clears it
+ * (without it the waits below just time out behind the modal's glass).
+ *
  * "Close project" is effectively a workbench rebuild -- the same Electron
  * window swaps out the project-bound page for a fresh no-project page. So we
  * wait not just for the console to come back, but for the new
@@ -218,6 +223,7 @@ export async function closeProjectIfOpen(page: Page): Promise<void> {
 
   await menu.click();
   await page.locator(CLOSE_PROJECT_MENU_ITEM).click();
+  await dismissSaveWorkspacePrompt(page);
   await page.waitForLoadState('load', { timeout: TIMEOUTS.sessionRestart }).catch(() => {});
   await page.waitForSelector(CONSOLE_INPUT, {
     state: 'visible',

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -646,7 +646,14 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    {
       if (!hasActiveEditor())
          return false;
-      Boolean dirty = activeColumn_.getActiveEditor().dirtyState().getValue();
+      return isDirty(activeColumn_.getActiveEditor());
+   }
+
+   // dirtyState() is a Value<Boolean> that can still be null before the
+   // editor finishes initializing, so treat "unknown" as clean.
+   private static boolean isDirty(EditingTarget editor)
+   {
+      Boolean dirty = editor.dirtyState().getValue();
       return dirty != null && dirty;
    }
 
@@ -1361,12 +1368,19 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    public void onDocumentResetToUntitled(DocumentResetToUntitledEvent event)
    {
       // Reuse an existing untitled doc if one is open. Untitled = no path.
+      //
+      // A *dirty* untitled doc is not reusable: revertUnsavedTargets below
+      // only reverts file-backed editors, so keeping it would carry the
+      // previous caller's unsaved text into the "clean slate" this event
+      // promises. That text then surfaces later as a modal Save File prompt
+      // the next time anything saves all documents, whose glass panel blocks
+      // every subsequent click. Close it with the rest and start fresh.
       String existingUntitledId = null;
       for (SourceColumn column : columnList_)
       {
          for (EditingTarget editor : column.getEditors())
          {
-            if (editor.getPath() == null)
+            if (editor.getPath() == null && !isDirty(editor))
             {
                existingUntitledId = editor.getId();
                break;


### PR DESCRIPTION
The all-platforms Playwright run on #18786 ([report](https://rstudio-playwright-reports.s3.amazonaws.com/pr-18786/34627740555-1/all-platforms/index.html)) reported 13 flaky tests across 6 files, with no hard failures. Five of the six files had a specific, identifiable race; this addresses those.

Several of them failed on **all four platforms at once**, which is the tell that they aren't timing noise -- they are state or protocol races that resolve the same way everywhere.

### 1. `resetToUntitled` kept a dirty Untitled placeholder (`markdown.test.ts`, all 4 platforms)

The failure surfaced as `focusConsole: console input did not hold focus ... something is stealing focus`. The screenshot shows why: a modal **Save File - Untitled1** dialog, holding `ggplot(mtcars, aes(wt, mpg)) + geom_point()` -- the last fixture from `ggplot_pipe_insert.test.ts`, which ran earlier in the same worker.

`resetSourcePaneState` keeps one Untitled tab open so the source pane never transits the zero-tab HIDE state (#17738), and it reuses whichever untitled doc is already open. `revertUnsavedTargets` only reverts *file-backed* editors, so a dirty placeholder carried the previous spec's text across. The next `saveAllSourceDocs` then prompted Save As for that pathless doc, and its glass panel blocked every later click.

- `SourceColumnManager.onDocumentResetToUntitled` now only reuses a **clean** untitled doc; a dirty one is closed with the rest and replaced (the existing create-then-close path already avoids the zero-tab gap). This event is only dispatched by the automation bridge, so it is test-facing only.
- `waitForSourcePaneReset` requires the settled doc to be clean, so a reuse regression fails loudly instead of silently.
- `closeSourceAndDeleteFile` drops its `saveAllSourceDocs` + `sleep(1000)`. The file is deleted on the next line, so the save changed nothing -- it was purely the thing that could raise a modal.

New spec `source_pane_reset.test.ts` covers the invariant; verified it fails (`dirty: true`) with the `SourceColumnManager` change reverted and passes with it.

### 2. `closeProjectIfOpen` waited behind "Save workspace image?" (`restart-under-agent.test.ts`, macOS + Windows)

`page.waitForFunction(() => project.isActive() === false)` timed out at 30s. The screenshot shows a **Close Project / Save workspace image to .../.RData?** prompt.

The sessions all run with `save_workspace: never`, so this looks impossible -- but `ApplicationQuit.saveAction_` is initialized to `SaveAction.saveAsk()` and only reaches the real value when the backend pushes `SaveActionChangedEvent`. A project closed seconds after it opened decides the quit inside that window and prompts. This spec closes projects in a tight open/close loop, so it lands there.

`dismissSaveWorkspacePrompt` (in `modals.page.ts`) clears it. It polls rather than waiting a fixed interval: in the common no-prompt case the quit proceeds instead, which flips `window.rstudio.ready` false or tears the context down, so a session that isn't going to prompt costs one poll.

`openProject` needs no equivalent -- the bridge fires `SwitchToProjectEvent` with `forceSaveAll=true`, which short-circuits before the prompt.

### 3. Editor keybindings load after `ready` (`console_editor_keybindings.test.ts`, Linux)

The startup spec reloads, waits for `window.rstudio.ready`, and presses the rebound shortcut. `ready` means R's deferred init finished; it says nothing about `EditorCommandManager`, which loads `editor_bindings.json` on `EditorLoadedEvent` through a separate async file read. The press can land before the rebinding exists and is swallowed (the console held `gamma delta`). Now the set/press/assert block is wrapped in `toPass()`, so the retry is the wait -- and a binding that never arrives still fails.

### 4. Clicking the editor before `newSourceDoc` produced one (`vimrc_keybindings.test.ts`, Windows)

`locator.click: Element is not visible` on `.ace_content`, with `force: true`. `force` skips the actionability checks, not the scroll-into-view that a zero-box element fails -- the click landed on the outgoing document's `ace_content`, still in the DOM but no longer rendered. `executeCommand(page, 'newSourceDoc')` only dispatches; the document is created over an RPC. Both tests now wait for the new editor to be active and painted. (The first test only passed because a polling assertion sat between the two steps.)

### 5. "No completions available" is terminal, not slow (`code_suggestions.test.ts`, all 4 platforms)

The status bar in the failure snapshot reads **"Posit AI Pass: No completions available."** -- the request completed with nothing. Nothing re-asks from there, so `toBeVisible({ timeout: 30s })` waited out the full budget for a suggestion that was never coming. That is a live model declining a context, and it declines the same context on every platform, which is how one empty answer became four flaky rows.

`expectGhostText` now re-issues `assistantRequestCompletions` when the status bar reports an empty response, and still fails if nothing ever arrives.

### Not changed: `rmarkdown.test.ts` "empty chunk does not define variables" (server-linux)

This one is not a test bug. The trace shows, right after `restartRRunAllChunks`:

```
Event listener stopped due to error (code=2, attempt=0); scheduling revival
WARNING: Error connecting with session.
1: jsonrpc error 1 (Unable to connect to service)
```

The session stayed unreachable for the whole 60s budget (revival cadence is 5s, so ~12 failed attempts), the console never got past `Restarting R session...`, and the toolbar was still showing the Session Suspended icon. The test's comment says its tight budget is deliberate -- it is the canary for #18340 -- so loosening it would hide exactly what it exists to catch. Leaving it to keep reporting.

### Verification

`npm run test:desktop-dev` on macOS, against a worktree `ant draft` build:

- `source_pane_reset.test.ts` -- passes; fails with the `SourceColumnManager` change reverted
- `ggplot_pipe_insert.test.ts` + `markdown.test.ts` + `source_pane_reset.test.ts` in order (the sequence that produced the flake), `--workers=1` -- 20 passed
- `vimrc_keybindings.test.ts` + `console_editor_keybindings.test.ts` -- 8 passed
- `projects/ignorefiles.test.ts` + `projects/project_editor_theme.test.ts` (close-project path) -- 7 passed
- `math_preview` + `rnotebook` + `notebook_inline_chunks` + `multiline_chunk_execution` (a sample of `closeSourceAndDeleteFile` callers) -- 11 passed

`code_suggestions.test.ts` needs AI credentials and can only be exercised in CI.

https://claude.ai/code/session_0142QsQiftXXnEQzetogGZbt