### PR TITLE
Fix Posit Assistant failing to start in a second RStudio instance on Windows

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -6576,11 +6576,16 @@ install_lock::InstallLock& installLock()
    // (it can be empty for dev/automation-launched sessions); the uuid
    // supplies the per-process uniqueness. Leftover files from dead
    // processes are stale-cleaned by the next mutator.
-   static const std::string ownerId =
-      module_context::activeSession().id().empty()
-         ? core::system::generateUuid(false)
-         : module_context::activeSession().id() + "-" +
-              core::system::generateUuid(false);
+   //
+   // Computed in a lambda rather than a conditional expression directly in
+   // the static's initializer: MSVC in C++20 mode initializes
+   // `static const std::string x = cond ? f() : g() + f();` to an empty
+   // string, which named every session's lock file ".lock" (#18787).
+   static const std::string ownerId = []() {
+      std::string sessionId = module_context::activeSession().id();
+      std::string uuid = core::system::generateUuid(false);
+      return sessionId.empty() ? uuid : sessionId + "-" + uuid;
+   }();
    static install_lock::InstallLock instance(
       xdg::userDataDir().completePath(chat_constants::kPositAiLocksDirName),
       ownerId);

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -6556,6 +6556,23 @@ void onShutdown(bool terminatedNormally)
    }
 }
 
+// The owner id names this session's lock file and must be unique per
+// process (see ChatInstallLock.hpp): the session id alone is stable
+// across a session relaunch, so an orphaned predecessor process that
+// outlives the relaunch (#18572) holds a live lock under the
+// replacement's own name, and every chat_start_backend in the
+// replacement then fails with a spurious "update in progress" (#18571).
+// The session id is kept as a prefix so lock files remain attributable
+// (it can be empty for dev/automation-launched sessions); the uuid
+// supplies the per-process uniqueness. Leftover files from dead
+// processes are stale-cleaned by the next mutator.
+std::string makeInstallLockOwnerId()
+{
+   std::string sessionId = module_context::activeSession().id();
+   std::string uuid = core::system::generateUuid(false);
+   return sessionId.empty() ? uuid : sessionId + "-" + uuid;
+}
+
 } // end anonymous namespace
 
 // ============================================================================
@@ -6565,30 +6582,14 @@ install_lock::InstallLock& installLock()
 {
    // Constructed lazily so xdg paths and activeSession() are initialized
    // (FileLock::initialize() has also run by first use; the helper creates
-   // its FileLock instances per-operation, not at construction).
-   // The owner id names this session's lock file and must be unique per
-   // process (see ChatInstallLock.hpp): the session id alone is stable
-   // across a session relaunch, so an orphaned predecessor process that
-   // outlives the relaunch (#18572) holds a live lock under the
-   // replacement's own name, and every chat_start_backend in the
-   // replacement then fails with a spurious "update in progress" (#18571).
-   // The session id is kept as a prefix so lock files remain attributable
-   // (it can be empty for dev/automation-launched sessions); the uuid
-   // supplies the per-process uniqueness. Leftover files from dead
-   // processes are stale-cleaned by the next mutator.
-   //
-   // Computed in a lambda rather than a conditional expression directly in
-   // the static's initializer: MSVC in C++20 mode initializes
-   // `static const std::string x = cond ? f() : g() + f();` to an empty
-   // string, which named every session's lock file ".lock" (#18787).
-   static const std::string ownerId = []() {
-      std::string sessionId = module_context::activeSession().id();
-      std::string uuid = core::system::generateUuid(false);
-      return sessionId.empty() ? uuid : sessionId + "-" + uuid;
-   }();
+   // its FileLock instances per-operation, not at construction). The owner
+   // id is passed straight to the constructor rather than held in its own
+   // `static const std::string`: MSVC in C++20 mode initializes such a
+   // static to an empty string when its initializer is a conditional
+   // expression, which named every session's lock file ".lock" (#18787).
    static install_lock::InstallLock instance(
       xdg::userDataDir().completePath(chat_constants::kPositAiLocksDirName),
-      ownerId);
+      makeInstallLockOwnerId());
    return instance;
 }
 // ============================================================================

--- a/src/cpp/session/modules/chat/ChatInstallLock.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.cpp
@@ -142,18 +142,9 @@ Error InstallLock::acquireInUse(Component component, uint64_t* pToken)
 {
    *pToken = 0;
 
-   // An empty owner id would name this session's lock file ".lock", a path
-   // every other session with the same defect shares, and the resulting
-   // contention would read as an update in progress (#18787). Refuse
-   // instead so the defect surfaces as a real error.
-   if (ownerId_.empty())
-   {
-      return systemError(
-         boost::system::errc::invalid_argument,
-         "The Posit Assistant install lock has no owner id; the session "
-         "lock file cannot be named",
-         ERROR_LOCATION);
-   }
+   Error error = checkOwnerId();
+   if (error)
+      return error;
 
    if (mutationActive_)
    {
@@ -165,7 +156,7 @@ Error InstallLock::acquireInUse(Component component, uint64_t* pToken)
 
    if (!anyComponentHeld())
    {
-      Error error = sessionLocksDir().ensureDirectory();
+      error = sessionLocksDir().ensureDirectory();
       if (error)
          return error;
 
@@ -270,7 +261,16 @@ Error InstallLock::tryBeginMutation(std::string* pUserMessage)
          ERROR_LOCATION);
    }
 
-   Error error = locksDir_.ensureDirectory();
+   Error error = checkOwnerId();
+   if (error)
+   {
+      *pUserMessage =
+         "Unable to verify the Posit Assistant installation state: " +
+         error.getMessage();
+      return error;
+   }
+
+   error = locksDir_.ensureDirectory();
    if (error)
    {
       *pUserMessage =
@@ -407,6 +407,24 @@ FilePath InstallLock::sessionLocksDir() const
 FilePath InstallLock::ownSessionLockPath() const
 {
    return sessionLocksDir().completePath(ownerId_ + kSessionLockSuffix);
+}
+
+Error InstallLock::checkOwnerId() const
+{
+   // An empty owner id would name this session's lock file ".lock", a path
+   // every other session with the same defect shares (#18787). A starter
+   // would then contend on it and report an update in progress; a mutator
+   // would take a foreign ".lock" for its own, skip probing it, and modify
+   // the installation under a live backend. Refuse both instead so the
+   // defect surfaces as a real error.
+   if (!ownerId_.empty())
+      return Success();
+
+   return systemError(
+      boost::system::errc::invalid_argument,
+      "The Posit Assistant install lock has no owner id; the session "
+      "lock file cannot be named",
+      ERROR_LOCATION);
 }
 
 boost::shared_ptr<FileLock> InstallLock::makeLock() const

--- a/src/cpp/session/modules/chat/ChatInstallLock.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.cpp
@@ -142,6 +142,19 @@ Error InstallLock::acquireInUse(Component component, uint64_t* pToken)
 {
    *pToken = 0;
 
+   // An empty owner id would name this session's lock file ".lock", a path
+   // every other session with the same defect shares, and the resulting
+   // contention would read as an update in progress (#18787). Refuse
+   // instead so the defect surfaces as a real error.
+   if (ownerId_.empty())
+   {
+      return systemError(
+         boost::system::errc::invalid_argument,
+         "The Posit Assistant install lock has no owner id; the session "
+         "lock file cannot be named",
+         ERROR_LOCATION);
+   }
+
    if (mutationActive_)
    {
       return systemError(

--- a/src/cpp/session/modules/chat/ChatInstallLock.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.cpp
@@ -376,6 +376,11 @@ bool InstallLock::mutationInProgress() const
    return mutationActive_;
 }
 
+const std::string& InstallLock::ownerId() const
+{
+   return ownerId_;
+}
+
 FilePath InstallLock::installLockPath() const
 {
    return locksDir_.completePath(kInstallLockFileName);

--- a/src/cpp/session/modules/chat/ChatInstallLock.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.hpp
@@ -152,6 +152,7 @@ public:
    // transitions via mutationInProgress() (in-process flag only; it never
    // probes the file — self-probing an advisory lock would release it).
    bool mutationInProgress() const;
+   const std::string& ownerId() const;
    core::FilePath installLockPath() const;
    core::FilePath sessionLocksDir() const;
 

--- a/src/cpp/session/modules/chat/ChatInstallLock.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.hpp
@@ -91,13 +91,12 @@ public:
                   boost::none);
 
    // Acquires the in-use lock (first component takes the file lock; the
-   // second just marks itself held). Fails if the owner id is empty (the
-   // lock file would be named ".lock" and shared by every session, #18787).
-   // Fails while this process's own mutation is active: a re-entrant start
-   // dispatched during the mutation must not launch from the directory being
-   // swapped, and the install.lock probe in acquireInUseForStart() cannot
-   // catch it (our own advisory lock does not conflict in-process), so this
-   // in-process check is the only guard.
+   // second just marks itself held). Fails if the owner id is empty (see
+   // checkOwnerId). Fails while this process's own mutation is active: a
+   // re-entrant start dispatched during the mutation must not launch from
+   // the directory being swapped, and the install.lock probe in
+   // acquireInUseForStart() cannot catch it (our own advisory lock does not
+   // conflict in-process), so this in-process check is the only guard.
    //
    // On success *pToken receives a generation token identifying this holder;
    // on failure it receives 0. Tokens are never 0, so callers may use 0 as a
@@ -139,6 +138,8 @@ public:
    // in the .cpp — excluding our own file by name (probing a lock this
    // process holds would release it under POSIX fcntl semantics). Files
    // whose probe acquisition succeeds are stale leftovers and are deleted.
+   // Fails if the owner id is empty (see checkOwnerId): the own-file
+   // exclusion would otherwise skip a foreign ".lock".
    //
    // On failure, *pUserMessage receives user-facing text describing why
    // (another mutator, or live sessions in use). This process's own held
@@ -160,6 +161,10 @@ public:
 
 private:
    core::FilePath ownSessionLockPath() const;
+   // Both entry points refuse an empty owner id, which would name this
+   // session's lock file ".lock" and share it with every other session that
+   // has the same defect (#18787).
+   core::Error checkOwnerId() const;
    boost::shared_ptr<core::FileLock> makeLock() const;
    core::FileLock::LockType effectiveLockType() const;
    bool anyComponentHeld() const;

--- a/src/cpp/session/modules/chat/ChatInstallLock.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallLock.hpp
@@ -91,11 +91,13 @@ public:
                   boost::none);
 
    // Acquires the in-use lock (first component takes the file lock; the
-   // second just marks itself held). Fails while this process's own mutation
-   // is active: a re-entrant start dispatched during the mutation must not
-   // launch from the directory being swapped, and the install.lock probe in
-   // acquireInUseForStart() cannot catch it (our own advisory lock does not
-   // conflict in-process), so this in-process check is the only guard.
+   // second just marks itself held). Fails if the owner id is empty (the
+   // lock file would be named ".lock" and shared by every session, #18787).
+   // Fails while this process's own mutation is active: a re-entrant start
+   // dispatched during the mutation must not launch from the directory being
+   // swapped, and the install.lock probe in acquireInUseForStart() cannot
+   // catch it (our own advisory lock does not conflict in-process), so this
+   // in-process check is the only guard.
    //
    // On success *pToken receives a generation token identifying this holder;
    // on failure it receives 0. Tokens are never 0, so callers may use 0 as a

--- a/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
@@ -13,18 +13,10 @@
  *
  */
 
-// Link-based locks are unsupported on Windows (FileLock forces advisory
-// there), and these tests rely on link-based semantics for cross-instance
-// exclusion within one process (POSIX fcntl advisory locks never conflict
-// in-process). The lock primitive itself is covered on Windows by
-// Win32FileLockTests.cpp; InstallLock's token/component state machine is
-// platform-independent and exercised here on POSIX.
-#ifndef _WIN32
-
 #include "ChatInstallLock.hpp"
 
-#include <sys/wait.h>
-#include <unistd.h>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -34,8 +26,22 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 
+#include "../SessionChat.hpp"
+
 using namespace rstudio::core;
 using namespace rstudio::session::modules::chat::install_lock;
+
+// Link-based locks are unsupported on Windows (FileLock forces advisory
+// there), and the tests in this block rely on link-based semantics for
+// cross-instance exclusion within one process (POSIX fcntl advisory locks
+// never conflict in-process). The lock primitive itself is covered on
+// Windows by Win32FileLockTests.cpp; InstallLock's token/component state
+// machine is platform-independent and exercised here on POSIX. The tests
+// after the block run everywhere.
+#ifndef _WIN32
+
+#include <sys/wait.h>
+#include <unistd.h>
 
 namespace {
 
@@ -695,3 +701,68 @@ TEST_F(ChatInstallLock, AcquireInUseForStartFailsClosedWhenInstallLockUninspecta
 } // anonymous namespace
 
 #endif // !_WIN32
+
+namespace {
+
+// Single-instance tests over a temp locks directory; advisory locks so they
+// run on every platform.
+class ChatInstallLockOwner : public testing::Test
+{
+protected:
+   void SetUp() override
+   {
+      FileLock::initialize();
+      ASSERT_FALSE(FilePath::tempFilePath(tempPath_));
+      locksDir_ = tempPath_.completePath("locks");
+   }
+
+   void TearDown() override
+   {
+      tempPath_.removeIfExists();
+   }
+
+   std::vector<std::string> sessionLockFileNames(const InstallLock& lock)
+   {
+      std::vector<FilePath> children;
+      Error error = lock.sessionLocksDir().getChildren(children);
+      EXPECT_FALSE(error);
+      std::vector<std::string> names;
+      for (const FilePath& child : children)
+         names.push_back(child.getFilename());
+      return names;
+   }
+
+   FilePath tempPath_;
+   FilePath locksDir_;
+};
+
+TEST_F(ChatInstallLockOwner, OwnerIdNamesTheSessionLockFile)
+{
+   InstallLock lock(locksDir_, "971bc367-abc123", FileLock::LOCKTYPE_ADVISORY);
+
+   uint64_t token = 0;
+   std::string userMessage;
+   ASSERT_FALSE(lock.acquireInUseForStart(
+      InstallLock::Component::ChatBackend, &token, &userMessage));
+   EXPECT_NE(token, 0u);
+
+   std::vector<std::string> names = sessionLockFileNames(lock);
+   ASSERT_EQ(names.size(), 1u);
+   EXPECT_EQ(names[0], "971bc367-abc123.lock");
+
+   lock.releaseInUse(InstallLock::Component::ChatBackend, token);
+   EXPECT_TRUE(sessionLockFileNames(lock).empty());
+}
+
+// The production accessor derives the owner id from the session id and a
+// per-process uuid. MSVC in C++20 mode initialized the previous form of
+// that static (a conditional expression) to an empty string, so every
+// Windows session locked "sessions/.lock" and the second instance refused
+// to start (#18787). Constructing the singleton touches no files.
+TEST(ChatInstallLockProduction, OwnerIdIsNotEmpty)
+{
+   EXPECT_FALSE(
+      rstudio::session::modules::chat::installLock().ownerId().empty());
+}
+
+} // anonymous namespace

--- a/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
@@ -27,6 +27,7 @@
 #include <shared_core/FilePath.hpp>
 
 #include "../SessionChat.hpp"
+#include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
 using namespace rstudio::session::modules::chat::install_lock;
@@ -772,15 +773,51 @@ TEST_F(ChatInstallLockOwner, EmptyOwnerIdIsRefusedNotSharedAsDotLock)
    EXPECT_FALSE(lock.sessionLocksDir().completePath(".lock").exists());
 }
 
-// The production accessor derives the owner id from the session id and a
-// per-process uuid. MSVC in C++20 mode initialized the previous form of
-// that static (a conditional expression) to an empty string, so every
-// Windows session locked "sessions/.lock" and the second instance refused
-// to start (#18787). Constructing the singleton touches no files.
-TEST(ChatInstallLockProduction, OwnerIdIsNotEmpty)
+// A mutator with an empty owner id would treat a foreign "sessions/.lock"
+// as its own and skip probing it, then modify the installation under a
+// live backend. It must refuse before taking install.lock.
+TEST_F(ChatInstallLockOwner, EmptyOwnerIdRefusesMutation)
 {
-   EXPECT_FALSE(
-      rstudio::session::modules::chat::installLock().ownerId().empty());
+   InstallLock lock(locksDir_, "", FileLock::LOCKTYPE_ADVISORY);
+
+   std::string userMessage;
+   Error error = lock.tryBeginMutation(&userMessage);
+   EXPECT_TRUE(error);
+   EXPECT_FALSE(lock.mutationInProgress());
+   EXPECT_NE(userMessage.find("Unable to verify"), std::string::npos);
+   EXPECT_EQ(userMessage.find("installing or updating"), std::string::npos);
+   EXPECT_FALSE(lock.installLockPath().exists());
+}
+
+// The production accessor derives the owner id from the session id and a
+// per-process uuid: "<sessionId>-<uuid>", or just "<uuid>" when the session
+// id is empty (dev/automation launches). The uuid suffix is what makes the
+// id unique per process (#18571); the bare session id would collide with an
+// orphaned predecessor. MSVC in C++20 mode initialized the previous form of
+// this id (a `static const std::string` with a conditional-expression
+// initializer) to an empty string, so every Windows session locked
+// "sessions/.lock" and the second instance refused to start (#18787).
+// Constructing the singleton touches no files.
+TEST(ChatInstallLockProduction, OwnerIdIsSessionIdPlusPerProcessUuid)
+{
+   using rstudio::session::module_context::activeSession;
+   const std::string& id =
+      rstudio::session::modules::chat::installLock().ownerId();
+   const std::string sessionId = activeSession().id();
+
+   // generateUuid(false) yields 32 hex digits with no dashes.
+   const std::size_t kUuidLength = 32;
+   ASSERT_GE(id.size(), kUuidLength);
+   EXPECT_NE(id, sessionId);
+
+   std::string uuid = id.substr(id.size() - kUuidLength);
+   EXPECT_EQ(uuid.find_first_not_of("0123456789abcdefABCDEF"),
+             std::string::npos)
+      << "owner id does not end in a uuid: " << id;
+
+   std::string prefix = id.substr(0, id.size() - kUuidLength);
+   EXPECT_EQ(prefix, sessionId.empty() ? "" : sessionId + "-")
+      << "owner id does not keep the session id prefix: " << id;
 }
 
 } // anonymous namespace

--- a/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallLockTests.cpp
@@ -754,6 +754,24 @@ TEST_F(ChatInstallLockOwner, OwnerIdNamesTheSessionLockFile)
    EXPECT_TRUE(sessionLockFileNames(lock).empty());
 }
 
+TEST_F(ChatInstallLockOwner, EmptyOwnerIdIsRefusedNotSharedAsDotLock)
+{
+   InstallLock lock(locksDir_, "", FileLock::LOCKTYPE_ADVISORY);
+
+   uint64_t token = 0;
+   std::string userMessage;
+   Error error = lock.acquireInUseForStart(
+      InstallLock::Component::ChatBackend, &token, &userMessage);
+   EXPECT_TRUE(error);
+   EXPECT_EQ(token, 0u);
+   EXPECT_FALSE(lock.inUseHeld());
+
+   // A missing owner id is a defect, not an update in progress.
+   EXPECT_NE(userMessage.find("Unable to verify"), std::string::npos);
+   EXPECT_EQ(userMessage.find("update is in progress"), std::string::npos);
+   EXPECT_FALSE(lock.sessionLocksDir().completePath(".lock").exists());
+}
+
 // The production accessor derives the owner id from the session id and a
 // per-process uuid. MSVC in C++20 mode initialized the previous form of
 // that static (a conditional expression) to an empty string, so every

--- a/version/news/os/NEWS-2026.09.1-autumn-hawkbit.md
+++ b/version/news/os/NEWS-2026.09.1-autumn-hawkbit.md
@@ -1,4 +1,4 @@
 ## RStudio 2026.09.1 "Autumn Hawkbit" Release Notes
 
 ### Fixed
-
+- ([#18787](https://github.com/rstudio/rstudio/issues/18787)): Fixed an issue on Windows where Posit Assistant failed to start in a second RStudio instance with "A Posit Assistant update is in progress".


### PR DESCRIPTION
### Intent

Fixes #18787. Replaces #18788, which targeted `main`; this is the same change based on `rel-autumn-hawkbit` for the 2026.09.1 patch.

On Windows, every RStudio session named its Posit Assistant "in use" lock file `pai/locks/sessions/.lock`, so a second instance collided with the first and Posit Assistant refused to start with "A Posit Assistant update is in progress".

The owner id that names the file is a function-local `static const std::string` initialized by a conditional expression. MSVC 19.51 in C++20 mode (which the Windows build uses) initializes that static to an empty string; the same code is correct in C++17 mode, as a non-static local, or when the initializer is wrapped in a lambda. The static was introduced by #18573, which is why 2026.08 is unaffected.

Upstream: this is a regression in MSVC 19.51 / Build Tools v14.51 (VS 2026 18.6+), which the Windows CI image uses via its VS 2026 18.7.3 pin; MSVC 19.29 through 19.50 compile the same code correctly. Microsoft tracks it as Developer Community ticket [11093947](https://developercommunity.visualstudio.com/t/MSVC-1451-codegen:-ternary-picks-wrong-/11093947), fixed in the v14.52 preview ([July 2026 preview notes](https://devblogs.microsoft.com/cppblog/msvc-build-tools-preview-updates-july-2026/)). No GA toolset carries the fix as of 2026-09-11, so the source-level workaround is required. Details in the issue.

### Approach

- Compute the owner id inside an immediately-invoked lambda with plain locals.
- `InstallLock::acquireInUse` refuses an empty owner id with a real error, so a regression surfaces as "Unable to verify the Posit Assistant installation state" instead of silently sharing one file and reporting an update in progress.
- Expose `InstallLock::ownerId()` as a test seam.

### Automated Tests

The lock tests were entirely `#ifndef _WIN32`, so nothing exercised owner-path naming on Windows. This PR moves the tests' common includes out of the POSIX-only block and adds three tests that compile everywhere:

- the session lock file is named `<owner>.lock`
- an empty owner id is refused without creating `.lock`
- the production accessor's owner id is non-empty (fails on the previous initializer under MSVC, passes with the fix)

### QA Notes

Verified on Windows 11 with the local dev build; QA notes added to the issue.

### Documentation

None; no user-facing behavior beyond the bug fix. NEWS entry added to `version/news/os/NEWS-2026.09.1-autumn-hawkbit.md`.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

