### PR TITLE
Backport Posit Assistant e2e fixes to rel-autumn-hawkbit

### DIFF
--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -54,7 +54,18 @@ export class ChatPane extends FramePageObject {
     // input is now a contenteditable <div class="tiptap-input-editor">, not a
     // <textarea>. editor.setEditable() toggles its contenteditable attribute.
     this.chatInput = this.frame.locator('.tiptap-input-editor');
-    this.messageItem = this.frame.locator('[data-message-id]');
+    // The ChatMessage row wrapper and the MessageRenderer content div nested
+    // inside it, so most messages match twice and last() lands on the content.
+    // An allowlist, not `[data-message-id]`: that attribute marks anything tied
+    // to a message, and PA 1.4.0 (#2395) began stamping it on a per-turn footer
+    // rendered *after* the row, which made last() resolve to a "8:54 PM" cost
+    // row. Matching what a message is works against both the released assistant
+    // and the pre-release builds the gate exercises. The row wrapper stays in
+    // the list because messages that render no MessageRenderer (application
+    // events, attachment-only) have no content div to match.
+    this.messageItem = this.frame.locator(
+      '[data-testid="chat-message-user"], [data-testid="chat-message-assistant"], [data-message-id].message-content'
+    );
     // Assistant-role bubbles only. The message wrapper carries the role via an
     // inner .chat-message-assistant / .chat-message-user class (ChatMessage.tsx),
     // so this excludes the user's own prompt bubble -- letting callers match on
@@ -158,10 +169,16 @@ export class ChatPane extends FramePageObject {
     // provider blip itself, so a failed lookup reads as "not substantive"
     // rather than erroring out of the caller's retry loop.
     return await this.messageItem.last().evaluate((el) => {
-      // Each message stamps data-message-id on both the ChatMessage row
-      // wrapper and the nested MessageRenderer content div, so last() lands
-      // on the inner div and the assistant class sits on an ancestor;
-      // closest() covers that shape, querySelector() the row wrapper.
+      // last() is normally the MessageRenderer content div, with the assistant
+      // class on an ancestor; for a message that renders no MessageRenderer it
+      // is the row wrapper, with the class on a descendant. closest() covers
+      // the first shape, querySelector() the second.
+      //
+      // Scoping to the content div rather than the row is what keeps a dead
+      // turn readable: the row also holds TurnRetryCallout, whose "Retry" /
+      // "Continue" button text would count as reply content below and report
+      // an empty turn as substantive, disabling the retry this predicate exists
+      // to trigger.
       if (!el.closest('.chat-message-assistant') && !el.querySelector('.chat-message-assistant')) {
         return false;
       }

--- a/e2e/rstudio/tests/auth.setup.ts
+++ b/e2e/rstudio/tests/auth.setup.ts
@@ -345,9 +345,11 @@ async function step<T>(page: Page, name: string, fn: () => Promise<T>, fatal = f
     const wrapped = `[authorize-posit] ${name} failed: ${msg} (page: ${url})`;
     // Failures at credential/authorization steps are fatal (LoginAutomationError);
     // non-credential steps stay transient so a flaky page load lets the Posit AI
-    // tests skip rather than failing the whole run. Note this classifies by
-    // step, not by error kind -- see the catch in the setup body.
-    throw fatal ? new LoginAutomationError(wrapped) : new Error(wrapped);
+    // tests skip rather than failing the whole run. A step that has already
+    // diagnosed a credential rejection itself throws LoginAutomationError, and
+    // that verdict is kept -- see the catch in the setup body.
+    const isFatal = fatal || err instanceof LoginAutomationError;
+    throw isFatal ? new LoginAutomationError(wrapped) : new Error(wrapped);
   }
 }
 
@@ -412,9 +414,36 @@ async function automateLogin(
       const passwordInput = page.locator('input[type="password"]');
       await passwordInput.waitFor({ state: 'visible' });
       await passwordInput.fill(password);
-      await page.getByRole('button', { name: /log.?in|sign.?in|continue/i }).click();
-      await page.waitForURL(/\/oauth\/device/, { timeout: 30000 });
-    }, true);
+      // noWaitAfter: click() otherwise waits for the navigation it triggers
+      // under the runner's actionTimeout (10s), which a slow redirect blew
+      // through and took the whole run down with it. Let the 30s URL wait
+      // below own that budget instead.
+      await page
+        .getByRole('button', { name: /log.?in|sign.?in|continue/i })
+        .click({ noWaitAfter: true });
+      const redirected = await page
+        .waitForURL(/\/oauth\/device/, { timeout: 30000 })
+        .then(() => true, () => false);
+      if (redirected)
+        return;
+
+      // Not redirected. A rejected password is the fatal case, and it shows
+      // up as an error message on the login page; anything else (a slow or
+      // stalled redirect) is transient and lets the Posit AI tests skip. The
+      // text patterns are deliberately narrow: ordinary login-page copy
+      // ("Wrong account?", "Try again") must not read as a rejection.
+      const rejection = page
+        .getByRole('alert')
+        .or(page.getByText(/incorrect|invalid|not recognized|does ?n.t match/i))
+        .first();
+      if (await rejection.isVisible().catch(() => false)) {
+        const rejectionText = await rejection.innerText().catch(() => '');
+        throw new LoginAutomationError(
+          `credentials rejected: ${rejectionText.trim().slice(0, 120)}`,
+        );
+      }
+      throw new Error('no redirect to /oauth/device within 30s of submitting the password');
+    });
     await step(page, 'enter user code', async () => {
       // _complete URL prefills the userCode form; navigate to the bare URI
       // for an empty form to type into.
@@ -512,12 +541,13 @@ function failIfStrict(providerLabel: string, reason: string): void {
 
 setup('authenticate Posit AI', async () => {
   // Explicit headroom above the flow's own budget: browser launch, five login
-  // steps (30s library default each on the raw chromium context -- the
-  // config's actionTimeout doesn't apply there), and the 90s token poll can
-  // legitimately exceed the global 120s test timeout. If the harness timeout
-  // fired here, the catch below would never run and every dependent test
-  // would be marked "did not run"; the withDeadline race below fails through
-  // the transient path well before this outer limit can be reached.
+  // steps (the runner applies the config's actionTimeout to contexts launched
+  // during a test, so 10s per action plus the password step's own 30s URL
+  // wait), and the 90s token poll can legitimately exceed the global 120s
+  // test timeout. If the harness timeout fired here, the catch below would
+  // never run and every dependent test would be marked "did not run"; the
+  // withDeadline race below fails through the transient path well before this
+  // outer limit can be reached.
   setup.setTimeout(240_000);
 
   const sandbox = process.env.PW_SANDBOX;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -326,6 +326,10 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@chat', '@serial'] }, 
     const lastMessage = chatPane.messageItem.last();
     const responseText = await lastMessage.innerText();
 
-    expect(responseText).toMatch(new RegExp(`skill:\\s*${USER_SKILL_NAME}`));
+    // Assistant 1.4.0+ prefixes every tool-call caption with U+200E (LEFT-TO-RIGHT
+    // MARK) so an rtl-truncated file path keeps its leading slash on the left. JS
+    // `\s` does not cover U+200E, so match it explicitly; the class also accepts
+    // the bare whitespace that 1.3.1 and earlier emit.
+    expect(responseText).toMatch(new RegExp(`skill:[\\s\\u200e]*${USER_SKILL_NAME}`));
   });
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
@@ -55,14 +55,14 @@ test.describe.serial('Conversation History', { tag: ['@ai', '@chat'] }, () => {
     await chatActions.openConversationHistory();
     await chatPane.getConversationItemByName(athenaName).first().click();
     await chatActions.closeConversationHistory();
-    const athenaMessages = chatPane.frame.locator('[data-message-id]');
+    const athenaMessages = chatPane.messageItem;
     await expect(athenaMessages.last()).toContainText('Athena', { timeout: 5000 });
 
     // Open history again for Aphrodite
     await chatActions.openConversationHistory();
     await chatPane.getConversationItemByName(aphroditeName).first().click();
     await chatActions.closeConversationHistory();
-    const aphroditeMessages = chatPane.frame.locator('[data-message-id]');
+    const aphroditeMessages = chatPane.messageItem;
     await expect(aphroditeMessages.last()).toContainText('Aphrodite', { timeout: 5000 });
 
     // Open history and delete Artemis conversation

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
@@ -18,7 +18,17 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@chat
   let consoleActions: ConsolePaneActions;
   let versions: EnvironmentVersions;
 
-  const PROMPT = 'Write R code that asks the user for their name and count how many letters there are in it. Use the readline command. Run the code.';
+  // Spelled out because the assistant otherwise sometimes reasons that
+  // readline() cannot work under a tool and writes the code into a source
+  // file instead of running it, and the notification never appears.
+  const PROMPT = 'Write R code that asks the user for their name with readline() and counts how many letters are in it. Run the code now with the executeCode tool; do not create or open a file.';
+
+  // The assistant's turn does not end when readline() returns: it typically
+  // reads the console back and comments on the result first, which has taken
+  // well over 30s on CI. Give that the same settle window the rest of the
+  // suite gives a turn, and size the test to hold two turns plus the readline.
+  const POST_READLINE_TURN_BUDGET_MS = 90000;
+  const TEST_TIMEOUT_MS = 300000;
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     ({ chatActions, chatPane, consoleActions, versions } = await setupPositAssistantChat(page));
@@ -29,6 +39,8 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@chat
   });
 
   test('notification appears when readline blocks, chat is unresponsive, and notification clears after input', async ({ rstudioPage: page }) => {
+    test.setTimeout(TEST_TIMEOUT_MS);
+
     // Start a fresh conversation
     await chatActions.startNewConversation();
 
@@ -82,7 +94,7 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@chat
     // isTurnIdle() rather than a raw stop-button sample: the button flickers
     // off between streaming phases, and a single hidden sample lands in that
     // gap often enough to be the flake this suite keeps hitting.
-    await expect.poll(() => chatActions.isTurnIdle(), { timeout: 30000 })
+    await expect.poll(() => chatActions.isTurnIdle(), { timeout: POST_READLINE_TURN_BUDGET_MS })
       .toBe(true);
 
     // Ask the assistant to print a Tempest quote to the console


### PR DESCRIPTION
Backports three e2e-only commits from `main`. The release branch's test runs
install the latest Posit Assistant release, so without these the Posit
Assistant suite fails on 1.4.0 and later.

- `9bae5ac43f` Match chat messages by role testid, not `data-message-id` (#18781).
  PA 1.4.0 added a per-turn footer that carries `data-message-id` and renders
  after the message row, so `messageItem.last()` resolved to a cost and timing
  row instead of the reply. Matches the `ChatMessage` row wrapper and the
  `MessageRenderer` content div instead, and routes the two inline
  `[data-message-id]` locators in `conversation-history` through the page object.

- `904450a2c7` Tolerate U+200E in the skill-selection e2e assertion (#18782).
  PA 1.4.0 prefixes every tool-call caption with LEFT-TO-RIGHT MARK, which
  JavaScript's `\s` class does not match, so the assertion failed against a
  rendered string that is visually identical to what it expected. The character
  class also accepts the bare whitespace 1.3.1 and earlier emit.

- `230931063e` Keep a slow Posit AI sign-in from failing the whole shard (#18780).
  A slow redirect after submitting the password was classified as a credential
  failure, which failed the auth setup project and left every dependent test as
  "did not run". Clicks with `noWaitAfter` so the 30s URL wait owns that budget,
  and treats the step as fatal only when the page shows a rejection message.
  Also widens the readline-notification test's settle window and has its prompt
  require the `executeCode` tool.

The first two match against both the currently released assistant and 1.4.0+,
so the suite passes whichever version a build pulls.

Cherry-picked clean with no conflicts. `npm run typecheck` passes in
`e2e/rstudio`, and `playwright test --list` enumerates all 84 Posit Assistant
tests.