### PR TITLE
hold rpc requests until client_init has returned

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
@@ -226,6 +226,8 @@ public class RpcRequest
    
    public void cancel()
    {
+      cancelled_ = true;
+
       if (request_ != null)
       {
          request_.cancel();
@@ -242,6 +244,18 @@ public class RpcRequest
    public String getUrl()
    {
       return url_;
+   }
+
+   // a request created before client_init returned has no client id; the
+   // server layer holds such requests and fills the id in before sending
+   public void setClientId(String clientId)
+   {
+      clientId_ = clientId != null ? new JSONString(clientId) : null;
+   }
+
+   public boolean isCancelled()
+   {
+      return cancelled_;
    }
 
    public String getMethod()
@@ -309,10 +323,11 @@ public class RpcRequest
    final private boolean redactLog_;
    final private String resultFieldName_;
    final private JSONString sourceWindow_;
-   final private JSONString clientId_;
+   private JSONString clientId_;
    final private JSONString clientVersion_;
    final private boolean refreshCredentials_;
    private Request request_ = null;
+   private boolean cancelled_ = false;
    private RequestLogEntry requestLogEntry_ = null;
    private static final CoreClientConstants constants_ = GWT.create(CoreClientConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -273,6 +273,7 @@ public class RemoteServer implements Server
       listeningForEvents_ = false;
       sessionRelaunchPending_ = false;
       pendingRequests_ = new ArrayList<PendingRpcRequest>();
+      preInitRequests_ = new ArrayList<PendingRpcRequest>();
       session_ = session;
       eventBus_ = eventBus;
       serverAuth_ = new RemoteServerAuth(this);
@@ -492,6 +493,9 @@ public class RemoteServer implements Server
             clientId_ = sessionInfo.getClientId();
             clientVersion_ = sessionInfo.getClientVersion();
             launchParameters_ = sessionInfo.getLaunchParameters();
+
+            sendPreInitRequests();
+
             requestCallback.onResponseReceived(sessionInfo);
          }
 
@@ -3881,6 +3885,20 @@ public class RemoteServer implements Server
             return rpcRequest;
          }
 
+         // Until client_init returns we have no client id, and the session
+         // answers any other request with INVALID_CLIENT_ID -- which we treat
+         // as "another client took over" and disconnect this one. Hold such
+         // requests until the id arrives; on the server, client_init can take
+         // seconds while rserver launches the session, so anything sent from
+         // an early callback (e.g. after Ace finishes loading) would hit this.
+         if (clientId_ == null && !canSendBeforeClientInit(rpcRequest))
+         {
+            Debug.log("Holding '" + rpcRequest.getMethod() + "' until client_init completes");
+            preInitRequests_.add(
+               new PendingRpcRequest(scope, rpcRequest, responseHandler, retryHandler));
+            return rpcRequest;
+         }
+
          // send the request
          rpcRequest.send(new RpcRequestCallback() {
             public void onError(RpcRequest request, RpcError error)
@@ -7172,6 +7190,36 @@ public class RemoteServer implements Server
       return request.getMethod().equals(AUTH_STATUS);
    }
 
+   // requests that legitimately go out before client_init has returned:
+   // client_init itself, the auth watcher, and abort (the "R is taking longer
+   // to start" dialog's Terminate R / Safe Mode buttons)
+   protected boolean canSendBeforeClientInit(RpcRequest request)
+   {
+      String method = request.getMethod();
+      return method.equals(CLIENT_INIT) ||
+             method.equals(AUTH_STATUS) ||
+             method.equals(ABORT);
+   }
+
+   private void sendPreInitRequests()
+   {
+      List<PendingRpcRequest> requests = preInitRequests_;
+      preInitRequests_ = new ArrayList<PendingRpcRequest>();
+
+      for (PendingRpcRequest request : requests)
+      {
+         if (request.request.isCancelled())
+            continue;
+
+         request.request.setClientId(clientId_);
+         sendRequest(
+            request.scope,
+            request.request,
+            request.responseHandler,
+            request.retryHandler);
+      }
+   }
+
    protected String clientInitId_ = "";
    private String clientId_;
    private String clientVersion_ = "";
@@ -7186,6 +7234,7 @@ public class RemoteServer implements Server
 
    private RemoteServerAuthWatcher authWatcher_;
    private List<PendingRpcRequest> pendingRequests_;
+   private List<PendingRpcRequest> preInitRequests_;
 
    private final RemoteServerAuth serverAuth_;
    private final RemoteServerEventListener serverEventListener_;


### PR DESCRIPTION
Follow-up to #18797, which showed how little it takes to bring a session down from the client side.

## Problem

Until `client_init` returns, `RemoteServer` has no client id, so any other RPC goes out without one. The session rejects it with `INVALID_CLIENT_ID`, and `RemoteServer.handleRpcErrorInternally` treats that code as "another client took over": it calls `disconnect()` and fires `ClientDisconnectedEvent`, which tears down the workbench. On desktop this is silent (the disconnected UI is server-only); on the server it leaves the workbench behind a glass pane.

Any early sender triggers it: an `AceEditor.load()` callback, a `Scheduler.scheduleDeferred` in an eagerly-constructed singleton, or `logException` for an exception thrown during startup. It never reproduces on desktop, where the session is up before the page loads and `client_init` returns in milliseconds, and only shows up on server CI, where `client_init` takes seconds while rserver launches the session -- and there it looks like a pile of unrelated project-switch flakes. In #18797's first run, 85 of 226 `client_init` calls on the linux-server shards had such a request racing them.

## Change

`RemoteServer.sendRequest` now holds requests while `clientId_` is null, the same way it already holds them while unauthorized, and sends them (with the id filled in) as soon as the `client_init` response arrives. `client_init` itself, `auth_status`, and `abort` (the "R is taking longer to start" dialog's Terminate R / Safe Mode buttons) still go straight out; the exemption list is a `protected` method so it can be extended. Each held request is logged via `Debug.log`, so a `client_init` race stays visible in the console without being fatal. `RpcRequest` gains `setClientId` for the replay and an `isCancelled` flag so a request cancelled while held is dropped rather than sent.

Satellite windows proxy their RPCs through the main window's `RemoteServer`, so they are covered by the same guard.

Verified with `ant javac`, and `console_editor_keybindings.test.ts` + `project_editor_theme.test.ts` on desktop against the worktree's `ant draft` build (8 passed). The server-side case is exercised by the PR-triggered linux-server e2e shards.
